### PR TITLE
Correcting The example of overriding test metrics

### DIFF
--- a/advancing-and-cancelling-steps.md
+++ b/advancing-and-cancelling-steps.md
@@ -22,11 +22,11 @@ To override important failures in the Code Quality, Security Test, and Performan
     "metrics": [
         {
             "kpi":"coverage",
-            "overridden":true
+            "override":true
         },
         {
             "kpi":"sqale_rating",
-            "overridden":true
+            "override":true
         }
     ]
 }


### PR DESCRIPTION
Current/wrong example:
{
    "metrics": [
        {
            "kpi":"coverage",
            "overridden":true
        },
        {
            "kpi":"sqale_rating",
            "overridden":true
        }
    ]
}

Correct/proposed example:
{
    "metrics": [
        {
            "kpi":"coverage",
            "override":true
        },
        {
            "kpi":"sqale_rating",
            "override":true
        }
    ]
}

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->


## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change follows the documentation style of this project.
- [ ] I have read the **CONTRIBUTING** document.
