### PR TITLE
Fix unclosed html tags

### DIFF
--- a/tutorial/1-a-basic-webhook.md
+++ b/tutorial/1-a-basic-webhook.md
@@ -17,14 +17,14 @@ Now you're ready to write the webhook script itself. Create a new file named `in
 The webhook script itself has four main parts. The first part is including the dependencies, loading the `.env` file, and setting up the Express application:
 
 ```javascript
-const express = require('express')
-const bodyParser = require('body-parser')
+const express = require("express");
+const bodyParser = require("body-parser");
 
-require('dotenv').config()
+require("dotenv").config();
 
-const app = express()
+const app = express();
 
-app.use(bodyParser.json())
+app.use(bodyParser.json());
 ```
 
 The second and third parts are the Express _routes_. These are JavaScript functions that handle specific request patterns. An Adobe I/O webhook must handle two different types of requests.
@@ -37,32 +37,32 @@ For the purpose of this tutorial, the path `/webhook` is used. This can be any p
 The challenge handler looks like this:
 
 ```javascript
-app.get('/webhook', (req, res) => {
-  if (req.query['challenge']) {
-    res.send(req.query['challenge'])
+app.get("/webhook", (req, res) => {
+  if (req.query["challenge"]) {
+    res.send(req.query["challenge"]);
   } else {
-    console.log('No challenge')
-    res.status(400)
+    console.log("No challenge");
+    res.status(400);
   }
-})
+});
 ```
 
-For the POST handler, at this point in the tutorial, it should just log the body and then write something trivial as a response. 
+For the POST handler, at this point in the tutorial, it should just log the body and then write something trivial as a response.
 
 ```javascript
-app.post('/webhook', (req, res) => {
-  console.log(req.body)
-  res.writeHead(200, { 'Content-Type': 'application/text' })
-  res.end('pong')
-})
+app.post("/webhook", (req, res) => {
+  console.log(req.body);
+  res.writeHead(200, { "Content-Type": "application/text" });
+  res.end("pong");
+});
 ```
 
 The last part of the script is to start listening for requests. Here, the `PORT` variable specified in the `.env` file is used.
 
 ```javascript
 const listener = app.listen(process.env.PORT, () => {
-  console.log(`Your app is listening on port ${listener.address().port}`)
-})
+  console.log(`Your app is listening on port ${listener.address().port}`);
+});
 ```
 
 ### Running the Webhook Script
@@ -104,7 +104,7 @@ Alternatively, you can run the webhook script using <a href="https://glitch.com/
 
 <!-- Remix Button -->
 <a href="https://glitch.com/edit/#!/remix/adobe-cloudmanager-api-tutorial-step1" target="_new">
-  <img src="../img/glitch.png" alt="Remix in Glitch" id="glitch-button">
+  <img src="../img/glitch.png" alt="Remix in Glitch" id="glitch-button"/>
 </a>
 
 > Feel free to create an account with Glitch if you want to continue to use it in subsequent steps of the tutorial.

--- a/tutorial/2-webhook-signature-validation.md
+++ b/tutorial/2-webhook-signature-validation.md
@@ -13,9 +13,9 @@ The `x-adobe-signature` header value is generated using the Client Secret value,
 Node.js's standard `crypto` module supports all of the cryptographic functions needed for this. It just needs to be added to the top of the script:
 
 ```javascript
-const express    = require('express'),
-      bodyParser = require('body-parser'),
-      crypto     = require('crypto');
+const express = require("express"),
+  bodyParser = require("body-parser"),
+  crypto = require("crypto");
 ```
 
 ### Writing the `verify` function
@@ -29,22 +29,24 @@ We also need to handle the case where the header isn't provided, so an `Error` s
 Fully implemented, the `verify` function looks like this:
 
 ```javascript
-app.use(bodyParser.json({
-  verify: (req, res, buf, encoding) => {
-    const signature = req.header('x-adobe-signature')
-    if (signature) {
-      const hmac = crypto.createHmac('sha256', process.env.CLIENT_SECRET)
-      hmac.update(buf)
-      const digest = hmac.digest('base64')
+app.use(
+  bodyParser.json({
+    verify: (req, res, buf, encoding) => {
+      const signature = req.header("x-adobe-signature");
+      if (signature) {
+        const hmac = crypto.createHmac("sha256", process.env.CLIENT_SECRET);
+        hmac.update(buf);
+        const digest = hmac.digest("base64");
 
-      if (signature !== digest) {
-        throw new Error('x-adobe-signature HMAC check failed')
+        if (signature !== digest) {
+          throw new Error("x-adobe-signature HMAC check failed");
+        }
+      } else if (!process.env.DEBUG && req.method === "POST") {
+        throw new Error("x-adobe-signature required");
       }
-    } else if (!process.env.DEBUG && req.method === 'POST') {
-      throw new Error('x-adobe-signature required')
-    }
-  }
-}))
+    },
+  })
+);
 ```
 
 ### Updating the Webhook
@@ -52,7 +54,7 @@ app.use(bodyParser.json({
 To update your webhook script, just replace the line
 
 ```javascript
-app.use(bodyParser.json())
+app.use(bodyParser.json());
 ```
 
 with the block above. If you are running the script locally, you'll need to stop and restart the node process. You don't need to restart ngrok. In fact, if you do restart ngrok, the URL will likely change and you'll need to go back into the <a href="https://console.adobe.io/integrations" target="_new">Adobe I/O Console</a> and update the Webhook URL.
@@ -61,7 +63,7 @@ If you are running the script through Glitch, Glitch will restart automatically.
 
 <!-- Remix Button -->
 <a href="https://glitch.com/edit/#!/remix/adobe-cloudmanager-api-tutorial-step2" target="_new">
-  <img src="../img/glitch.png" alt="Remix in Glitch" id="glitch-button">
+  <img src="../img/glitch.png" alt="Remix in Glitch" id="glitch-button"/>
 </a>
 
 #### Next Step

--- a/tutorial/3-handling-specific-events.md
+++ b/tutorial/3-handling-specific-events.md
@@ -7,21 +7,25 @@ As seen in [Step 1](1-a-basic-webhook.md), webhooks can be registered for one or
 Replace the `app.post` block with this code:
 
 ```javascript
-app.post('/webhook', (req, res) => {
-  res.writeHead(200, { 'Content-Type': 'application/text' })
-  res.end('pong')
+app.post("/webhook", (req, res) => {
+  res.writeHead(200, { "Content-Type": "application/text" });
+  res.end("pong");
 
-  const STARTED = 'https://ns.adobe.com/experience/cloudmanager/event/started'
-  const EXECUTION = 'https://ns.adobe.com/experience/cloudmanager/pipeline-execution'
+  const STARTED = "https://ns.adobe.com/experience/cloudmanager/event/started";
+  const EXECUTION =
+    "https://ns.adobe.com/experience/cloudmanager/pipeline-execution";
 
-  const event = req.body.event
+  const event = req.body.event;
 
-  if (STARTED === event['@type'] &&
-       EXECUTION === event['xdmEventEnvelope:objectType']) {
-    console.log('received execution start event')
+  if (
+    STARTED === event["@type"] &&
+    EXECUTION === event["xdmEventEnvelope:objectType"]
+  ) {
+    console.log("received execution start event");
   }
-})
+});
 ```
+
 Now when a Pipeline Execution Started event is received, the message `received execution start event` will be logged.
 
 ### Running the Updated Webhook
@@ -32,7 +36,7 @@ If you are running the script through Glitch, Glitch will restart automatically.
 
 <!-- Remix Button -->
 <a href="https://glitch.com/edit/#!/remix/adobe-cloudmanager-api-tutorial-step3" target="_new">
-  <img src="../img/glitch.png" alt="Remix in Glitch" id="glitch-button">
+  <img src="../img/glitch.png" alt="Remix in Glitch" id="glitch-button"/>
 </a>
 
 #### Next Step

--- a/tutorial/4-getting-an-access-token.md
+++ b/tutorial/4-getting-an-access-token.md
@@ -21,13 +21,13 @@ If you are running the webhook in Glitch, you'll need to edit the `package.json`
 The header of the script also needs to be updated to include these new dependencies, along with the `URLSearchParams` class:
 
 ```javascript
-const express = require('express')
-const bodyParser = require('body-parser')
-const crypto = require('crypto')
-const jsrsasign = require('jsrsasign')
-const fetch = require('node-fetch')
+const express = require("express");
+const bodyParser = require("body-parser");
+const crypto = require("crypto");
+const jsrsasign = require("jsrsasign");
+const fetch = require("node-fetch");
 
-const { URLSearchParams } = require('url')
+const { URLSearchParams } = require("url");
 ```
 
 ### Writing the `getAccessToken` Function
@@ -35,36 +35,44 @@ const { URLSearchParams } = require('url')
 As the code to obtain an access token is fairly complicated, it makes sense to organize it into a separate function. The function has three parts. First, it generates the JWT payload, then the signed token is created, and then the exchange is done. Finally, the function returns the access token.
 
 ```javascript
-async function getAccessToken () {
-  const EXPIRATION = 60 * 60 // 1 hour
+async function getAccessToken() {
+  const EXPIRATION = 60 * 60; // 1 hour
 
   const header = {
-    'alg': 'RS256',
-    'typ': 'JWT'
-  }
+    alg: "RS256",
+    typ: "JWT",
+  };
 
   const payload = {
-    'exp': Math.round(new Date().getTime() / 1000) + EXPIRATION,
-    'iss': process.env.ORGANIZATION_ID,
-    'sub': process.env.TECHNICAL_ACCOUNT_ID,
-    'aud': `https://ims-na1.adobelogin.com/c/${process.env.API_KEY}`,
-    'https://ims-na1.adobelogin.com/s/ent_cloudmgr_sdk': true
-  }
+    exp: Math.round(new Date().getTime() / 1000) + EXPIRATION,
+    iss: process.env.ORGANIZATION_ID,
+    sub: process.env.TECHNICAL_ACCOUNT_ID,
+    aud: `https://ims-na1.adobelogin.com/c/${process.env.API_KEY}`,
+    "https://ims-na1.adobelogin.com/s/ent_cloudmgr_sdk": true,
+  };
 
-  const jwtToken = jsrsasign.jws.JWS.sign('RS256', JSON.stringify(header), JSON.stringify(payload), process.env.PRIVATE_KEY)
+  const jwtToken = jsrsasign.jws.JWS.sign(
+    "RS256",
+    JSON.stringify(header),
+    JSON.stringify(payload),
+    process.env.PRIVATE_KEY
+  );
 
-  const response = await fetch('https://ims-na1.adobelogin.com/ims/exchange/jwt', {
-    method: 'POST',
-    body: new URLSearchParams({
-      client_id: process.env.API_KEY,
-      client_secret: process.env.CLIENT_SECRET,
-      jwt_token: jwtToken
-    })
-  })
+  const response = await fetch(
+    "https://ims-na1.adobelogin.com/ims/exchange/jwt",
+    {
+      method: "POST",
+      body: new URLSearchParams({
+        client_id: process.env.API_KEY,
+        client_secret: process.env.CLIENT_SECRET,
+        jwt_token: jwtToken,
+      }),
+    }
+  );
 
-  const json = await response.json()
+  const json = await response.json();
 
-  return json['access_token']
+  return json["access_token"];
 }
 ```
 
@@ -73,13 +81,15 @@ async function getAccessToken () {
 The access token is an asynchronous function so it returns a `Promise`. So logging of the access token (which is all we're doing in this step) has to be done in a closure invoked when the Promise is resolved:
 
 ```javascript
-  if (STARTED === event['@type'] &&
-       EXECUTION === event['xdmEventEnvelope:objectType']) {
-    console.log('received execution start event')
-    getAccessToken().then(accessToken => {
-      console.log(accessToken)
-    })
-  }
+if (
+  STARTED === event["@type"] &&
+  EXECUTION === event["xdmEventEnvelope:objectType"]
+) {
+  console.log("received execution start event");
+  getAccessToken().then((accessToken) => {
+    console.log(accessToken);
+  });
+}
 ```
 
 ### Running the Updated Webhook
@@ -90,7 +100,7 @@ If you are running the script through Glitch, Glitch will restart automatically.
 
 <!-- Remix Button -->
 <a href="https://glitch.com/edit/#!/remix/adobe-cloudmanager-api-tutorial-step4" target="_new">
-  <img src="../img/glitch.png" alt="Remix in Glitch" id="glitch-button">
+  <img src="../img/glitch.png" alt="Remix in Glitch" id="glitch-button"/>
 </a>
 
 #### Next Step

--- a/tutorial/5-getting-the-execution.md
+++ b/tutorial/5-getting-the-execution.md
@@ -8,24 +8,24 @@ Making an API call to Cloud Manager requires several headers to be passed. Since
 
 The function itself is pretty simple -- it accepts the access token, a URL, and an HTTP method and then makes a request to that URL with the supplied method setting the three required headers:
 
-* `x-gw-ims-org-id` - the Organization ID (contained in the `ORGANIZATION_ID` variable)
-* `x-api-key` - the API Key (contained in the `API_KEY` variable)
-* `Authorization` - contains the access token
+- `x-gw-ims-org-id` - the Organization ID (contained in the `ORGANIZATION_ID` variable)
+- `x-api-key` - the API Key (contained in the `API_KEY` variable)
+- `Authorization` - contains the access token
 
 The function then returns the response body as a JavaScript object.
 
 ```javascript
-async function makeApiCall (accessToken, url, method) {
+async function makeApiCall(accessToken, url, method) {
   const response = await fetch(url, {
-    'method': method,
-    'headers': {
-      'x-gw-ims-org-id': process.env.ORGANIZATION_ID,
-      'x-api-key': process.env.API_KEY,
-      'Authorization': `Bearer ${accessToken}`
-    }
-  })
+    method: method,
+    headers: {
+      "x-gw-ims-org-id": process.env.ORGANIZATION_ID,
+      "x-api-key": process.env.API_KEY,
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
 
-  return response.json()
+  return response.json();
 }
 ```
 
@@ -34,10 +34,10 @@ async function makeApiCall (accessToken, url, method) {
 With the generic function in place, the function to get an execution is pretty simple. It just needs to call the `getAccessToken` function (created in the last step) and then makes a GET request to the execution URL.
 
 ```javascript
-async function getExecution (executionUrl) {
-  const accessToken = await getAccessToken()
+async function getExecution(executionUrl) {
+  const accessToken = await getAccessToken();
 
-  return makeApiCall(accessToken, executionUrl, 'GET')
+  return makeApiCall(accessToken, executionUrl, "GET");
 }
 ```
 
@@ -46,16 +46,18 @@ async function getExecution (executionUrl) {
 Finally, we can call the `getExecution` function with the URL contained in the event payload. There's a variety of information in the execution response (take a look at the [API Reference](../swagger-specs/api.yaml) for all the details), but for now let's just log the execution id.
 
 ```javascript
-  if (STARTED === event['@type'] &&
-       EXECUTION === event['xdmEventEnvelope:objectType']) {
-    console.log('received execution start event')
+if (
+  STARTED === event["@type"] &&
+  EXECUTION === event["xdmEventEnvelope:objectType"]
+) {
+  console.log("received execution start event");
 
-    const executionUrl = event['activitystreams:object']['@id']
+  const executionUrl = event["activitystreams:object"]["@id"];
 
-    getExecution(executionUrl).then(execution => {
-      console.log(`Execution ${execution.id} started`)
-    })
-  }
+  getExecution(executionUrl).then((execution) => {
+    console.log(`Execution ${execution.id} started`);
+  });
+}
 ```
 
 ### Running the Updated Webhook
@@ -66,7 +68,7 @@ If you are running the script through Glitch, Glitch will restart automatically.
 
 <!-- Remix Button -->
 <a href="https://glitch.com/edit/#!/remix/adobe-cloudmanager-api-tutorial-step5" target="_new">
-  <img src="../img/glitch.png" alt="Remix in Glitch" id="glitch-button">
+  <img src="../img/glitch.png" alt="Remix in Glitch" id="glitch-button"/>
 </a>
 
 #### Next Step

--- a/tutorial/6-getting-the-program.md
+++ b/tutorial/6-getting-the-program.md
@@ -1,8 +1,8 @@
 ## Tutorial Step 6 - Navigating Between API Calls
 
-While the execution information is interesting, what we actually want to send in the notification sent to Microsoft Teams or Slack is the program name. This isn't in the execution response but has to be requested from a different URL, one following the pattern `/api/program/{programId}`. 
+While the execution information is interesting, what we actually want to send in the notification sent to Microsoft Teams or Slack is the program name. This isn't in the execution response but has to be requested from a different URL, one following the pattern `/api/program/{programId}`.
 
-While it is possible for you to formulate the URL, it is a best practice to follow the links provided in the API response. The Cloud Manager API responses use a convention named <a href="https://en.wikipedia.org/wiki/Hypertext_Application_Language" target="_new">Hypertext Application Language</a> (HAL for short) to define links. But you don't really need to know too many details of HAL to use the API. The important part is that in the API response, there is a `_links` object which contains a set of objects. Each of these objects has a meaningful name that tells the API consumer where the link goes and the `href` property of the object has the destination. 
+While it is possible for you to formulate the URL, it is a best practice to follow the links provided in the API response. The Cloud Manager API responses use a convention named <a href="https://en.wikipedia.org/wiki/Hypertext_Application_Language" target="_new">Hypertext Application Language</a> (HAL for short) to define links. But you don't really need to know too many details of HAL to use the API. The important part is that in the API response, there is a `_links` object which contains a set of objects. Each of these objects has a meaningful name that tells the API consumer where the link goes and the `href` property of the object has the destination.
 
 For example, in an execution response, you will see this:
 
@@ -32,10 +32,11 @@ Note that these links are _relative_ to the domain name for the API. As with the
 This might be overkill for this tutorial, since we only need a single link, but getting a link from an API response is a common enough task that it makes sense to make a separate function for this. It's fairly straightforward object navigation:
 
 ```javascript
-function getLink (obj, linkType) {
-  return obj['_links'][linkType].href
+function getLink(obj, linkType) {
+  return obj["_links"][linkType].href;
 }
 ```
+
 ### Updating the `getExecution` Method
 
 To get the program data based on the execution, first you get the link to the program from the execution response. Remember -- at this point it will be a server-relative path. Then, you use the Node.js `URL` class to turn that path into an absolute URL and pass this URL to the `makeApiCall` function to get the program. Finally, the program response is added to the execution response.
@@ -43,25 +44,25 @@ To get the program data based on the execution, first you get the link to the pr
 Although the `URL` class is built-in to Node.js, it does need to be imported from the `url` module. We already are doing this for the `URLSearchParams` class (added in Step 4), so that line can simply be updated to import both classes.
 
 ```javascript
-const { URLSearchParams, URL } = require('url')
+const { URLSearchParams, URL } = require("url");
 ```
 
 The updated `getExecution` function looks like this:
 
 ```javascript
-async function getExecution (executionUrl) {
-  const accessToken = await getAccessToken()
+async function getExecution(executionUrl) {
+  const accessToken = await getAccessToken();
 
-  const execution = await makeApiCall(accessToken, executionUrl, 'GET')
+  const execution = await makeApiCall(accessToken, executionUrl, "GET");
 
-  const REL_PROGRAM = 'http://ns.adobe.com/adobecloud/rel/program'
-  const programLink = getLink(execution, REL_PROGRAM)
-  const programUrl = new URL(programLink, executionUrl)
-  const program = await makeApiCall(accessToken, programUrl)
+  const REL_PROGRAM = "http://ns.adobe.com/adobecloud/rel/program";
+  const programLink = getLink(execution, REL_PROGRAM);
+  const programUrl = new URL(programLink, executionUrl);
+  const program = await makeApiCall(accessToken, programUrl);
 
-  execution.program = program
+  execution.program = program;
 
-  return execution
+  return execution;
 }
 ```
 
@@ -70,16 +71,18 @@ async function getExecution (executionUrl) {
 Now that `getExecution` returns the Program information as part of the `execution` object, we can easily change the log message to output the program name instead of the execution id.
 
 ```javascript
-  if (STARTED === event['@type'] &&
-       EXECUTION === event['xdmEventEnvelope:objectType']) {
-    console.log('received execution start event')
+if (
+  STARTED === event["@type"] &&
+  EXECUTION === event["xdmEventEnvelope:objectType"]
+) {
+  console.log("received execution start event");
 
-    const executionUrl = event['activitystreams:object']['@id']
+  const executionUrl = event["activitystreams:object"]["@id"];
 
-    getExecution(executionUrl).then(execution => {
-      console.log(`Execution for ${execution.program.name} started`)
-    })
-  }
+  getExecution(executionUrl).then((execution) => {
+    console.log(`Execution for ${execution.program.name} started`);
+  });
+}
 ```
 
 ### Running the Updated Webhook
@@ -90,7 +93,7 @@ If you are running the script through Glitch, Glitch will restart automatically.
 
 <!-- Remix Button -->
 <a href="https://glitch.com/edit/#!/remix/adobe-cloudmanager-api-tutorial-step6" target="_new">
-  <img src="../img/glitch.png" alt="Remix in Glitch" id="glitch-button">
+  <img src="../img/glitch.png" alt="Remix in Glitch" id="glitch-button"/>
 </a>
 
 #### Next Step

--- a/tutorial/7-sending-notifications.md
+++ b/tutorial/7-sending-notifications.md
@@ -15,30 +15,32 @@ Documentation to create a webhook URL for Slack can be found <a href="https://ap
 Sending a Slack notification can be done with just a simple JSON object containing a `text` property. Let's create a new function which sends such an object to the webhook. To make the webhook easy to chnage, add a new variable to your `.env` file named `SLACK_WEBHOOK` and create this function:
 
 ```javascript
-function notifySlack (message) {
+function notifySlack(message) {
   fetch(process.env.SLACK_WEBHOOK, {
-    'method': 'POST',
-    'headers': { 'Content-Type': 'application/json' },
-    'body': JSON.stringify({
-      'text': message
-    })
-  })
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      text: message,
+    }),
+  });
 }
 ```
 
 And the invoke this function instead of logging:
 
 ```javascript
-  if (STARTED === event['@type'] &&
-       EXECUTION === event['xdmEventEnvelope:objectType']) {
-    console.log('received execution start event')
+if (
+  STARTED === event["@type"] &&
+  EXECUTION === event["xdmEventEnvelope:objectType"]
+) {
+  console.log("received execution start event");
 
-    const executionUrl = event['activitystreams:object']['@id']
+  const executionUrl = event["activitystreams:object"]["@id"];
 
-    getExecution(executionUrl).then(execution => {
-      notifySlack(`Execution for ${execution.program.name} started`)
-    })
-  }
+  getExecution(executionUrl).then((execution) => {
+    notifySlack(`Execution for ${execution.program.name} started`);
+  });
+}
 ```
 
 This will produce a Slack message which looks like this:
@@ -49,7 +51,7 @@ This will produce a Slack message which looks like this:
 
 <!-- Remix Button -->
 <a href="https://glitch.com/edit/#!/remix/adobe-cloudmanager-api-tutorial-step7-slack" target="_new">
-  <img src="../img/glitch.png" alt="Remix in Glitch" id="glitch-button">
+  <img src="../img/glitch.png" alt="Remix in Glitch" id="glitch-button"/>
 </a>
 
 #### Notifying Microsoft Teams
@@ -57,18 +59,18 @@ This will produce a Slack message which looks like this:
 Sending a Microsoft Teams notification can be as simple as Slack -- just a single `text` property. But Teams also supports some slightly fancier formatting options -- notifications can have a title and banner color, among other options. As with the Slack webhook, you should put the webhook URL in your `.env` file in a variable named `TEAMS_WEBHOOK`.
 
 ```javascript
-function notifyTeams (message) {
+function notifyTeams(message) {
   fetch(process.env.TEAMS_WEBHOOK, {
-    'method': 'POST',
-    'headers': { 'Content-Type': 'application/json' },
-    'body': JSON.stringify({
-      '@context': 'https://schema.org/extensions',
-      '@type': 'MessageCard',
-      'themeColor': '0072C6',
-      'title': 'Update from Cloud Manager',
-      'text': message
-    })
-  })
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      "@context": "https://schema.org/extensions",
+      "@type": "MessageCard",
+      themeColor: "0072C6",
+      title: "Update from Cloud Manager",
+      text: message,
+    }),
+  });
 }
 ```
 
@@ -77,16 +79,18 @@ function notifyTeams (message) {
 And then invoke this function:
 
 ```javascript
-  if (STARTED === event['@type'] &&
-       EXECUTION === event['xdmEventEnvelope:objectType']) {
-    console.log('received execution start event')
+if (
+  STARTED === event["@type"] &&
+  EXECUTION === event["xdmEventEnvelope:objectType"]
+) {
+  console.log("received execution start event");
 
-    const executionUrl = event['activitystreams:object']['@id']
+  const executionUrl = event["activitystreams:object"]["@id"];
 
-    getExecution(executionUrl).then(execution => {
-      notifyTeams(`Execution for ${execution.program.name} started`)
-    })
-  }
+  getExecution(executionUrl).then((execution) => {
+    notifyTeams(`Execution for ${execution.program.name} started`);
+  });
+}
 ```
 
 This will produce a Microsoft Teams message which looks like this:
@@ -95,12 +99,5 @@ This will produce a Microsoft Teams message which looks like this:
 
 <!-- Remix Button -->
 <a href="https://glitch.com/edit/#!/remix/adobe-cloudmanager-api-tutorial-step7-msteams" target="_new">
-  <img src="../img/glitch.png" alt="Remix in Glitch" id="glitch-button">
+  <img src="../img/glitch.png" alt="Remix in Glitch" id="glitch-button"/>
 </a>
-
-<style type="text/css">
-#kirbyMainContent .hljs .hljs-function,
-#kirbyMainContent .hljs .hljs-params {
-    color: #333;
-}
-</style>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We are moving to a new parser for markdown content. It requires html tags to be closed so this PR fixes the instances of `<img>` that should be `<img/>`.

## Related Issue

n/a

## Motivation and Context

Sets up the repo to be parsed by our our new internal/external documentation sites.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My change follows the documentation style of this project.
- [x] I have read the **CONTRIBUTING** document.
