### PR TITLE
Fix return type for getStepLogs

### DIFF
--- a/swagger-specs/api.yaml
+++ b/swagger-specs/api.yaml
@@ -774,6 +774,8 @@ paths:
       responses:
         '200':
           description: Successful retrieval of logs
+          schema:
+            $ref: '#/definitions/Redirect'
         '403':
           description: Missing permission for user to read logs
         '404':
@@ -2209,3 +2211,11 @@ definitions:
       name:
         type: string
         description: 'Name of the log for service in environment. Example: aemerror'
+  Redirect:
+    type: object
+    required:
+      - redirect
+    properties:
+      redirect:
+        type: string
+        description: 'The url to redirect to.'


### PR DESCRIPTION
This closes #9

## Motivation and Context

Without this change Swagger will generate a method returning void. That makes it impossible to retrieve the actual URL.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My change follows the documentation style of this project.
- [x] I have read the **CONTRIBUTING** document.
