### PR TITLE
Update content flow API with unsupported AMS operation

### DIFF
--- a/swagger-specs/api.yaml
+++ b/swagger-specs/api.yaml
@@ -4125,7 +4125,7 @@ paths:
       tags:
         - ContentSets
       summary: Cancel content flow
-      description: Cancel content flow
+      description: Cancel content flow (Cloud Service only).
       operationId: cancelContentFlow
       parameters:
         - name: programId


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
AMS Content copy does not support Cancel content flow. This PR adds this information to the description of  Cancel content flow API.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
