### PR TITLE
Fix playground table

### DIFF
--- a/src/components/playground/link-table.js
+++ b/src/components/playground/link-table.js
@@ -19,6 +19,25 @@ import CustomRequestDialog from './custom-request-dialog'
 import { Edit } from '@adobe/gatsby-theme-aio/src/components/Icons'
 import TemplatedRequestDialog from './template-request-dialog'
 
+const EmptyLinkTable = () => (
+  <Table width="100%">
+    <THead>
+      <Tr>
+        <Th>rel</Th>
+        <Th>href</Th>
+        <Th>actions</Th>
+      </Tr>
+    </THead>
+    <TBody>
+      <Tr>
+        <Td></Td>
+        <Td></Td>
+        <Td></Td>
+      </Tr>
+    </TBody>
+  </Table>
+);
+
 const LinkTable = ({
   links,
   setRequest,
@@ -27,6 +46,13 @@ const LinkTable = ({
 }) => {
   const [customDialogOpen, setCustomDialogOpen] = useState(null)
   const [templatedDialogOpen, setTemplatedDialogOpen] = useState(null)
+
+  const linksKeys = Object.keys(links);
+  const hasLinks = linksKeys.length > 0;
+
+  if (!hasLinks) {
+    return <EmptyLinkTable />;
+  }
 
   return (
       <Table width="100%">


### PR DESCRIPTION
## Description

Cloud Manager API playground screen fails with a TypeError, because of the aio-theme upgrade. The current aio-theme version introduces a breaking change on the `TBody` component from the `link-table` component.

Added an empty table placeholder when links are not available.

## Related Issue

#248

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
