### PR TITLE
xref to feature docs CQDOC-20637

### DIFF
--- a/swagger-specs/api.yaml
+++ b/swagger-specs/api.yaml
@@ -4031,7 +4031,7 @@ paths:
       tags:
         - ContentSets
       summary: Execute content flow using content set
-      description: Executes a content flow
+      description: 'Executes a content flow. Note that the user must have appropriate rights in both the source and destination environments. See https://experienceleague.adobe.com/docs/experience-manager-cloud-service/content/implementing/developer-tools/content-copy.html for more information.'
       operationId: createContentFlow
       parameters:
         - name: programId


### PR DESCRIPTION
xref to feature docs CQDOC-20637

## Description

A request came in to clarify that the user must have appropriate permissions on both source and destination environments when invoking a content copy via API

## Related Issue

CQDOC-20637

## Motivation and Context

Avoid a common user pitfall

## How Has This Been Tested?

No test needed, doc update

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation change

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
