### PR TITLE
CMGR-58775 - add pagination to public doc for ssl certificates

### DIFF
--- a/swagger-specs/api.yaml
+++ b/swagger-specs/api.yaml
@@ -3005,6 +3005,19 @@ paths:
           description: Identifier of the program
           required: true
           type: string
+        - name: start
+          in: query
+          description: Pagination start parameter
+          required: false
+          type: string
+          default: "0"
+        - name: limit
+          in: query
+          description: Pagination limit parameter
+          required: false
+          type: integer
+          default: 20
+          format: int32
         - name: domain
           in: query
           description: Domain name used for filtering the certificates


### PR DESCRIPTION
Add the pagination query params to the ssl certificates api

## Description

New pagination query params were added with default values as part of the API contract

