### PR TITLE
Added compatibility check into the public api docs

### DIFF
--- a/swagger-specs/api.yaml
+++ b/swagger-specs/api.yaml
@@ -24,10 +24,8 @@ tags:
   - name: Environment Restore From Backup
   - name: IP Allowlist
   - name: IP Allowlist Binding
-  - name: Domain
-  - name: Domain Mappings - CDN Configurations
-  - name: SSL Certificates
-  - name: EDS Sites
+  - name: Domain Names
+  - name: SSLCertificates
   - name: Tenants
   - name: Regions
   - name: Network infrastructure
@@ -1142,6 +1140,7 @@ paths:
             - prod
             - rde
             - preprod
+            - devxl
         - name: x-gw-ims-org-id
           in: header
           description: IMS organization ID that the request is being made under.
@@ -2132,7 +2131,7 @@ paths:
           description: IP Allowlist
           required: true
           schema:
-            $ref: '#/definitions/Updateanipallowlist'
+            $ref: '#/definitions/IPAllowedList'
         - name: x-gw-ims-org-id
           in: header
           description: IMS organization ID that the request is being made under.
@@ -2290,6 +2289,51 @@ paths:
             $ref: '#/definitions/IPAllowedListBinding'
         '404':
           description: IP Allowlist not found
+  '/api/program/{programId}/ipAllowlist/{ipAllowlistId}/binding/{ipAllowlistBindingId}/retry':
+    put:
+      tags:
+        - IP Allowlist Binding
+      summary: Retry IP Allowlist binding action
+      description: Retry the IP Allowlist binding action for the program and IP Allowlist id
+      operationId: retryIPAllowlistBinding
+      parameters:
+        - name: programId
+          in: path
+          description: Identifier of the program
+          required: true
+          type: string
+        - name: ipAllowlistId
+          in: path
+          description: Identifier of the IP Allowlist
+          required: true
+          type: string
+        - name: ipAllowlistBindingId
+          in: path
+          description: Identifier of the IP Allowlist binding
+          required: true
+          type: string
+        - name: x-gw-ims-org-id
+          in: header
+          description: IMS organization ID that the request is being made under.
+          required: true
+          type: string
+        - name: Authorization
+          in: header
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          required: true
+          type: string
+        - name: x-api-key
+          in: header
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          required: true
+          type: string
+      responses:
+        '202':
+          description: Retry operation was successful
+          schema:
+            $ref: '#/definitions/IPAllowedListBinding'
+        '404':
+          description: IP Allowlist not found
   '/api/program/{programId}/ipAllowlist/{ipAllowlistId}/bindings':
     get:
       tags:
@@ -2440,7 +2484,7 @@ paths:
           description: IP Allowlist
           required: true
           schema:
-            $ref: '#/definitions/Createanewipallowlist'
+            $ref: '#/definitions/IPAllowedList'
         - name: x-gw-ims-org-id
           in: header
           description: IMS organization ID that the request is being made under.
@@ -2476,39 +2520,32 @@ paths:
           description: Program not found
         '412':
           description: Creating IP Allowlists for non cloud programs is not supported
-  '/api/program/{programId}/domains':
+  '/api/program/{programId}/domainNames':
     get:
       tags:
-        - Domain
-      summary: Get list of domains
-      description: ''
-      operationId: getDomain
+        - Domain Names
+      summary: List Domain Names
+      description: Lists all domain names in an program
+      operationId: getDomainNames
       parameters:
         - name: programId
           in: path
-          description: Identifier of program id
+          description: Identifier of the program
           required: true
           type: string
-        - name: name
+        - name: start
           in: query
-          description: Domain name
+          description: Pagination start parameter
           required: false
           type: string
-        - name: anyVerified
+          default: '0'
+        - name: limit
           in: query
-          description: Filter any verified
+          description: Pagination limit parameter
           required: false
-          type: boolean
-        - name: isTxt
-          in: query
-          description: Is TXT verified
-          required: false
-          type: boolean
-        - name: isAcme
-          in: query
-          description: Is ACME verified
-          required: false
-          type: boolean
+          type: integer
+          default: 20
+          format: int32
         - name: x-gw-ims-org-id
           in: header
           description: IMS organization ID that the request is being made under.
@@ -2526,27 +2563,27 @@ paths:
           type: string
       responses:
         '200':
-          description: List of domains received
+          description: successful operation
           schema:
-            $ref: '#/definitions/Domain'
+            $ref: '#/definitions/DomainNameList'
     post:
       tags:
-        - Domain
-      summary: Create a domain
-      description: ''
-      operationId: createDomain
+        - Domain Names
+      summary: Create a Domain name
+      description: Create a new Domain name for an Environment
+      operationId: createEnvironmentDomainName
       parameters:
         - name: programId
           in: path
-          description: Identifier of program
+          description: Identifier of the program
           required: true
           type: string
         - in: body
           name: body
-          description: Payload for creating a domain
+          description: Domain Name
           required: true
           schema:
-            $ref: '#/definitions/DomainCreate'
+            $ref: '#/definitions/NewDomainName'
         - name: x-gw-ims-org-id
           in: header
           description: IMS organization ID that the request is being made under.
@@ -2568,30 +2605,28 @@ paths:
           required: true
           type: string
       responses:
-        '200':
-          description: Domain created
+        '201':
+          description: Domain name created
           schema:
-            $ref: '#/definitions/Domain'
+            $ref: '#/definitions/DomainName'
         '404':
-          description: Program not found
-        '409':
-          description: Domain already exists
-  '/api/program/{programId}/domain/{domain-id}':
+          description: Resource not found
+  '/api/program/{programId}/domainName/{domainNameId}':
     get:
       tags:
-        - Domain
-      summary: Get domain
-      description: ''
-      operationId: getDomain
+        - Domain Names
+      summary: Get Domain Name
+      description: Returns a domain name by its id
+      operationId: getEnvironmentDomainName
       parameters:
         - name: programId
           in: path
-          description: Identifier of program id
+          description: Identifier of the program
           required: true
           type: string
-        - name: domain-id
+        - name: domainNameId
           in: path
-          description: Identifier of domain id
+          description: Domain Name id
           required: true
           type: string
         - name: x-gw-ims-org-id
@@ -2611,430 +2646,32 @@ paths:
           type: string
       responses:
         '200':
-          description: Domain received
+          description: successful operation
           schema:
-            $ref: '#/definitions/Domain'
-        '404':
-          description: Domain not found
+            $ref: '#/definitions/DomainName'
     put:
       tags:
-        - Domain
-      summary: Update domain
-      description: ''
-      operationId: modifyDomain
+        - Domain Names
+      summary: Update Domain Name
+      description: Updates a domain name by its id.
+      operationId: updateEnvironmentDomainName
       parameters:
         - name: programId
           in: path
-          description: Identifier of program id
+          description: Identifier of the program
           required: true
           type: string
-        - name: domain-id
+        - name: domainNameId
           in: path
-          description: Identifier of domain id
+          description: Identifier of the domain name
           required: true
           type: string
         - in: body
           name: body
-          description: Domain Update Body
+          description: Updated domain name
           required: true
           schema:
-            $ref: '#/definitions/UpdateaDomain''snameorlabel'
-        - name: x-gw-ims-org-id
-          in: header
-          description: IMS organization ID that the request is being made under.
-          required: true
-          type: string
-        - name: Authorization
-          in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
-          required: true
-          type: string
-        - name: x-api-key
-          in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
-          required: true
-          type: string
-        - name: Content-Type
-          in: header
-          description: Must always be application/json
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Domain updated
-          schema:
-            $ref: '#/definitions/Domain'
-        '404':
-          description: Program not found
-    delete:
-      tags:
-        - Domain
-      summary: Delete a domain
-      description: ''
-      operationId: deleteDomain
-      parameters:
-        - name: programId
-          in: path
-          description: Identifier of program id
-          required: true
-          type: string
-        - name: domain-id
-          in: path
-          description: Identifier of domain id
-          required: true
-          type: string
-        - name: x-gw-ims-org-id
-          in: header
-          description: IMS organization ID that the request is being made under.
-          required: true
-          type: string
-        - name: Authorization
-          in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
-          required: true
-          type: string
-        - name: x-api-key
-          in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Domain deleted
-          schema:
-            $ref: '#/definitions/Response'
-  '/api/program/{programId}/domain/{domain-id}/validate':
-    put:
-      tags:
-        - Domain
-      summary: Check validation
-      description: ''
-      operationId: domainValidationToken
-      parameters:
-        - name: programId
-          in: path
-          description: Identifier of program id
-          required: true
-          type: string
-        - name: domain-id
-          in: path
-          description: Identifier of domain id
-          required: true
-          type: string
-        - in: body
-          name: body
-          description: Payload for validation operation
-          required: true
-          schema:
-            $ref: '#/definitions/DomainTokenValidationBody'
-        - name: x-gw-ims-org-id
-          in: header
-          description: IMS organization ID that the request is being made under.
-          required: true
-          type: string
-        - name: Authorization
-          in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
-          required: true
-          type: string
-        - name: x-api-key
-          in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
-          required: true
-          type: string
-        - name: Content-Type
-          in: header
-          description: Must always be application/json
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Validation is completed
-          schema:
-            $ref: '#/definitions/Domain'
-        '404':
-          description: Program not found
-  '/api/program/{programId}/domain/{domain-id}/validation':
-    post:
-      tags:
-        - Domain
-      summary: Creates validation token
-      description: ''
-      operationId: domainValidationToken
-      parameters:
-        - name: programId
-          in: path
-          description: Identifier of program id
-          required: true
-          type: string
-        - name: domain-id
-          in: path
-          description: Identifier of domain id
-          required: true
-          type: string
-        - in: body
-          name: body
-          description: Payload for validation operation
-          required: true
-          schema:
-            $ref: '#/definitions/DomainTokenValidationBody'
-        - name: x-gw-ims-org-id
-          in: header
-          description: IMS organization ID that the request is being made under.
-          required: true
-          type: string
-        - name: Authorization
-          in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
-          required: true
-          type: string
-        - name: x-api-key
-          in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
-          required: true
-          type: string
-        - name: Content-Type
-          in: header
-          description: Must always be application/json
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Created validation token
-          schema:
-            $ref: '#/definitions/Domain'
-        '404':
-          description: Program Not found
-  '/api/program/{programId}/domain-mapping/{domainMappingId}':
-    get:
-      tags:
-        - Domain Mappings - CDN Configurations
-      summary: Get domain mapping
-      description: ''
-      operationId: getDomainMappingById
-      parameters:
-        - name: programId
-          in: path
-          description: Identifier of program
-          required: true
-          type: integer
-          format: int64
-        - name: domainMappingId
-          in: path
-          description: Identifier of domain mapping
-          required: true
-          type: integer
-          format: int64
-        - name: x-gw-ims-org-id
-          in: header
-          description: IMS organization ID that the request is being made under.
-          required: true
-          type: string
-        - name: Authorization
-          in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
-          required: true
-          type: string
-        - name: x-api-key
-          in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Domain Mapping retrieved
-          schema:
-            $ref: '#/definitions/DomainMapping'
-        '404':
-          description: Domain Mapping not found
-    put:
-      tags:
-        - Domain Mappings - CDN Configurations
-      summary: Update domain mapping
-      description: ''
-      operationId: updateDomainMapping
-      parameters:
-        - name: programId
-          in: path
-          description: Identifier of program
-          required: true
-          type: integer
-          format: int64
-        - name: domainMappingId
-          in: path
-          description: Identifier of domain mapping
-          required: true
-          type: integer
-          format: int64
-        - in: body
-          name: body
-          description: Payload for updating a domain mapping
-          required: true
-          schema:
-            $ref: '#/definitions/Updateadomainmapping'
-        - name: x-gw-ims-org-id
-          in: header
-          description: IMS organization ID that the request is being made under.
-          required: true
-          type: string
-        - name: Authorization
-          in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
-          required: true
-          type: string
-        - name: x-api-key
-          in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
-          required: true
-          type: string
-        - name: Content-Type
-          in: header
-          description: Must always be application/json
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Domain Mapping updated
-          schema:
-            $ref: '#/definitions/DomainMapping'
-        '404':
-          description: Domain Mapping not found
-    delete:
-      tags:
-        - Domain Mappings - CDN Configurations
-      summary: Delete domain mapping
-      description: ''
-      operationId: deleteDomainMapping
-      parameters:
-        - name: programId
-          in: path
-          description: Identifier of program
-          required: true
-          type: integer
-          format: int64
-        - name: domainMappingId
-          in: path
-          description: Identifier of domain mapping
-          required: true
-          type: integer
-          format: int64
-        - name: x-gw-ims-org-id
-          in: header
-          description: IMS organization ID that the request is being made under.
-          required: true
-          type: string
-        - name: Authorization
-          in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
-          required: true
-          type: string
-        - name: x-api-key
-          in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Domain Mapping deleted
-          schema:
-            $ref: '#/definitions/DomainMapping'
-        '404':
-          description: Domain Mapping not found
-  '/api/program/{programId}/domain-mapping/{domainMappingId}/verify':
-    put:
-      tags:
-        - Domain Mappings - CDN Configurations
-      summary: Check if customer made the required DNS changes
-      description: ''
-      operationId: validateHelixDomain
-      parameters:
-        - name: programId
-          in: path
-          description: Identifier of program
-          required: true
-          type: integer
-          format: int64
-        - name: domainMappingId
-          in: path
-          description: Identifier of domain mapping
-          required: true
-          type: integer
-          format: int64
-        - name: x-gw-ims-org-id
-          in: header
-          description: IMS organization ID that the request is being made under.
-          required: true
-          type: string
-        - name: Authorization
-          in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
-          required: true
-          type: string
-        - name: x-api-key
-          in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
-          required: true
-          type: string
-      responses:
-        '200':
-          description: DNS changes were successfully made
-          schema:
-            $ref: '#/definitions/DomainMapping'
-        '404':
-          description: Program not found
-  '/api/program/{programId}/domain-mappings':
-    get:
-      tags:
-        - Domain Mappings - CDN Configurations
-      summary: List of domain mappings
-      description: ''
-      operationId: getAllDomainMappingsByProgramId
-      parameters:
-        - name: programId
-          in: path
-          description: Identifier of program
-          required: true
-          type: integer
-          format: int64
-        - name: x-gw-ims-org-id
-          in: header
-          description: IMS organization ID that the request is being made under.
-          required: true
-          type: string
-        - name: Authorization
-          in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
-          required: true
-          type: string
-        - name: x-api-key
-          in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
-          required: true
-          type: string
-      responses:
-        '200':
-          description: List of domain mappings retrieved
-          schema:
-            $ref: '#/definitions/DomainMappingList'
-    post:
-      tags:
-        - Domain Mappings - CDN Configurations
-      summary: Create domain mapping
-      description: ''
-      operationId: createDomainMapping
-      parameters:
-        - name: programId
-          in: path
-          description: Identifier of program
-          required: true
-          type: integer
-          format: int64
-        - in: body
-          name: body
-          description: Payload for creating a domain mapping
-          required: true
-          schema:
-            $ref: '#/definitions/Createanewdomainmapping'
+            $ref: '#/definitions/DomainName'
         - name: x-gw-ims-org-id
           in: header
           description: IMS organization ID that the request is being made under.
@@ -3059,111 +2696,70 @@ paths:
         '200':
           description: successful operation
           schema:
-            $ref: '#/definitions/DomainMapping'
-        '201':
-          description: Domain Mapping created
+            $ref: '#/definitions/DomainName'
+        '202':
+          description: Updating domain name
           schema:
-            $ref: '#/definitions/DomainMapping'
-  '/api/program/{programId}/environment/{environmentId}/domain-mappings':
-    get:
+            $ref: '#/definitions/DomainName'
+        '404':
+          description: Resource not found
+    delete:
       tags:
-        - Domain Mappings - CDN Configurations
-      summary: List of domain mappings by environment
-      description: ''
-      operationId: getAllDomainMappingsByProgramIdAndEnvironmentId
-      parameters:
-        - name: programId
-          in: path
-          description: Identifier of program
-          required: true
-          type: integer
-          format: int64
-        - name: environmentId
-          in: path
-          description: Identifier of environment
-          required: true
-          type: integer
-          format: int64
-        - name: x-gw-ims-org-id
-          in: header
-          description: IMS organization ID that the request is being made under.
-          required: true
-          type: string
-        - name: Authorization
-          in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
-          required: true
-          type: string
-        - name: x-api-key
-          in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
-          required: true
-          type: string
-      responses:
-        '200':
-          description: List of domain mappings by environment retrieved
-          schema:
-            $ref: '#/definitions/DomainMappingList'
-  '/api/program/{programId}/site/{siteId}/domain-mappings':
-    get:
-      tags:
-        - Domain Mappings - CDN Configurations
-      summary: List of domain mappings by EDS site
-      description: ''
-      operationId: getAllDomainMappingsByProgramIdAndSiteId
-      parameters:
-        - name: programId
-          in: path
-          description: Identifier of program
-          required: true
-          type: integer
-          format: int64
-        - name: siteId
-          in: path
-          description: Identifier of EDS site
-          required: true
-          type: integer
-          format: int64
-        - name: x-gw-ims-org-id
-          in: header
-          description: IMS organization ID that the request is being made under.
-          required: true
-          type: string
-        - name: Authorization
-          in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
-          required: true
-          type: string
-        - name: x-api-key
-          in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
-          required: true
-          type: string
-      responses:
-        '200':
-          description: List of domain mappings by environment retrieved
-          schema:
-            $ref: '#/definitions/DomainMappingList'
-  '/api/program/{programId}/certificate/{certificateId}':
-    get:
-      tags:
-        - SSL Certificates
-      summary: Get certificate by ID
-      description: ''
-      operationId: getCertificateByIdAndProgramId
+        - Domain Names
+      summary: Delete Domain Name
+      description: Deletes a domain name by its id
+      operationId: deleteEnvironmentDomainName
       parameters:
         - name: programId
           in: path
           description: Identifier of the program
           required: true
-          type: integer
-          format: int64
-        - name: certificateId
+          type: string
+        - name: domainNameId
           in: path
-          description: Identifier of the certificate
+          description: Identifier of the Domain Name
           required: true
-          type: integer
-          format: int64
+          type: string
+        - name: x-gw-ims-org-id
+          in: header
+          description: IMS organization ID that the request is being made under.
+          required: true
+          type: string
+        - name: Authorization
+          in: header
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          required: true
+          type: string
+        - name: x-api-key
+          in: header
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          required: true
+          type: string
+      responses:
+        '202':
+          description: Deleting domain Name
+          schema:
+            $ref: '#/definitions/DomainName'
+        '404':
+          description: Resource not found
+  '/api/program/{programId}/domainName/{domainNameId}/deploy':
+    post:
+      tags:
+        - Domain Names
+      summary: Verify and deploy a Domain name
+      description: Verify and deploy a Domain name
+      operationId: deployDomainName
+      parameters:
+        - name: programId
+          in: path
+          description: Identifier of the program
+          required: true
+          type: string
+        - name: domainNameId
+          in: path
+          description: Domain Name id
+          required: true
+          type: string
         - name: x-gw-ims-org-id
           in: header
           description: IMS organization ID that the request is being made under.
@@ -3181,38 +2777,162 @@ paths:
           type: string
       responses:
         '200':
-          description: Certificate retrieved
+          description: Domain name verified
           schema:
-            $ref: '#/definitions/SslCertificateRepresentation'
+            $ref: '#/definitions/DomainName'
         '404':
-          description: Certificate not found
+          description: Resource not found
+  '/api/program/{programId}/domainName/{domainNameId}/verify':
+    post:
+      tags:
+        - Domain Names
+      summary: Makes a DNS resolution
+      description: Make a DNS resolution
+      operationId: verifyDomainName
+      parameters:
+        - name: programId
+          in: path
+          description: Identifier of the program
+          required: true
+          type: string
+        - name: domainNameId
+          in: path
+          description: Identifier of the domain name
+          required: true
+          type: string
+        - name: x-gw-ims-org-id
+          in: header
+          description: IMS organization ID that the request is being made under.
+          required: true
+          type: string
+        - name: Authorization
+          in: header
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          required: true
+          type: string
+        - name: x-api-key
+          in: header
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          required: true
+          type: string
+      responses:
+        '200':
+          description: successful operation
           schema:
-            $ref: '#/definitions/SslCertificateNotFoundException'
+            $ref: '#/definitions/DomainName'
+        '202':
+          description: Domain name is being verified
+          schema:
+            $ref: '#/definitions/DomainName'
+        '404':
+          description: Resource not found
+  '/api/program/{programId}/domainNames/validate':
+    post:
+      tags:
+        - Domain Names
+      summary: Validate an Domain name
+      description: Validate a new Domain name
+      operationId: validateDomainName
+      parameters:
+        - name: programId
+          in: path
+          description: Identifier of the program
+          required: true
+          type: string
+        - in: body
+          name: body
+          description: Domain name to be validated
+          required: true
+          schema:
+            $ref: '#/definitions/DomainNameValidate'
+        - name: x-gw-ims-org-id
+          in: header
+          description: IMS organization ID that the request is being made under.
+          required: true
+          type: string
+        - name: Authorization
+          in: header
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          required: true
+          type: string
+        - name: x-api-key
+          in: header
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          required: true
+          type: string
+        - name: Content-Type
+          in: header
+          description: Must always be application/json
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Domain name successfully validated
+          schema:
+            $ref: '#/definitions/DomainName'
+        '404':
+          description: Resource not found
+  '/api/program/{programId}/certificate/{certificateId}':
+    get:
+      tags:
+        - SSLCertificates
+      summary: Get SSL Certificate
+      description: Returns an SSL Certificate by its id
+      operationId: getCertificate
+      parameters:
+        - name: programId
+          in: path
+          description: Identifier of the program
+          required: true
+          type: string
+        - name: certificateId
+          in: path
+          description: Identifier of the certificate
+          required: true
+          type: string
+        - name: x-gw-ims-org-id
+          in: header
+          description: IMS organization ID that the request is being made under.
+          required: true
+          type: string
+        - name: Authorization
+          in: header
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          required: true
+          type: string
+        - name: x-api-key
+          in: header
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          required: true
+          type: string
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            $ref: '#/definitions/SslCertificate'
     put:
       tags:
-        - SSL Certificates
-      summary: Update certificate
-      description: ''
+        - SSLCertificates
+      summary: Update SSL Certificate
+      description: Update a certificate.
       operationId: updateCertificate
       parameters:
         - name: programId
           in: path
           description: Identifier of the program
           required: true
-          type: integer
-          format: int64
+          type: string
         - name: certificateId
           in: path
           description: Identifier of the certificate
           required: true
-          type: integer
-          format: int64
+          type: string
         - in: body
           name: body
-          description: Payload for updating the certificate
+          description: Updated certificate
           required: true
           schema:
-            $ref: '#/definitions/CreateOrUpdateSslCertificateBody'
+            $ref: '#/definitions/SslCertificate'
         - name: x-gw-ims-org-id
           in: header
           description: IMS organization ID that the request is being made under.
@@ -3237,30 +2957,26 @@ paths:
         '200':
           description: Certificate updated
           schema:
-            $ref: '#/definitions/SslCertificateRepresentation'
+            $ref: '#/definitions/SslCertificate'
         '404':
-          description: Certificate not found
-          schema:
-            $ref: '#/definitions/SslCertificateNotFoundException'
+          description: Resource not found
     delete:
       tags:
-        - SSL Certificates
-      summary: Delete a certificate
-      description: ''
+        - SSLCertificates
+      summary: Delete SSL Certificate
+      description: Delete an SSL Certificate.
       operationId: deleteCertificate
       parameters:
         - name: programId
           in: path
           description: Identifier of the program
           required: true
-          type: integer
-          format: int64
+          type: string
         - name: certificateId
           in: path
           description: Identifier of the certificate
           required: true
-          type: integer
-          format: int64
+          type: string
         - name: x-gw-ims-org-id
           in: header
           description: IMS organization ID that the request is being made under.
@@ -3277,28 +2993,30 @@ paths:
           required: true
           type: string
       responses:
-        '200':
+        '204':
           description: Certificate deleted
           schema:
-            $ref: '#/definitions/SslCertificateRepresentation'
+            $ref: '#/definitions/SslCertificate'
         '404':
-          description: Certificate not found
-          schema:
-            $ref: '#/definitions/SslCertificateNotFoundException'
+          description: Resource not found
   '/api/program/{programId}/certificates':
     get:
       tags:
-        - SSL Certificates
-      summary: Get all certificates
-      description: ''
-      operationId: getAllCertificatesForProgram
+        - SSLCertificates
+      summary: List certificates
+      description: Lists all certificates in a program
+      operationId: getCertificates
       parameters:
         - name: programId
           in: path
           description: Identifier of the program
           required: true
-          type: integer
-          format: int64
+          type: string
+        - name: domain
+          in: query
+          description: Domain name used for filtering the certificates
+          required: false
+          type: string
         - name: start
           in: query
           description: Pagination start parameter
@@ -3312,29 +3030,6 @@ paths:
           type: integer
           default: 20
           format: int32
-        - name: status
-          in: query
-          description: Filter statuses separated by comma
-          required: false
-          type: string
-          enum:
-            - VALID
-            - PENDING
-            - EXPIRED
-        - name: name
-          in: query
-          description: Certificate name
-          required: false
-          type: string
-        - name: sslCertificateType
-          in: query
-          description: Certificate types separated by comma.
-          required: false
-          type: string
-          enum:
-            - DV
-            - EV
-            - OV
         - name: x-gw-ims-org-id
           in: header
           description: IMS organization ID that the request is being made under.
@@ -3352,28 +3047,29 @@ paths:
           type: string
       responses:
         '200':
-          description: Certificate list retrieved
+          description: Successful retrieval of certificates list
           schema:
-            $ref: '#/definitions/AllSSLCertificatesList'
+            $ref: '#/definitions/CertificatesList'
+        '404':
+          description: Program not found
     post:
       tags:
-        - SSL Certificates
-      summary: Create SSL certificate
-      description: ''
-      operationId: createSslCertificate
+        - SSLCertificates
+      summary: Create SSL Certificate
+      description: Create a new certificate.
+      operationId: createCertificate
       parameters:
         - name: programId
           in: path
           description: Identifier of the program
           required: true
-          type: integer
-          format: int64
+          type: string
         - in: body
           name: body
-          description: Payload for creating the certificate
+          description: Certificate
           required: true
           schema:
-            $ref: '#/definitions/CreateOrUpdateSslCertificateBody'
+            $ref: '#/definitions/NewSslCertificate'
         - name: x-gw-ims-org-id
           in: header
           description: IMS organization ID that the request is being made under.
@@ -3395,286 +3091,12 @@ paths:
           required: true
           type: string
       responses:
-        '200':
-          description: successful operation
-          schema:
-            $ref: '#/definitions/SslCertificateRepresentation'
         '201':
-          description: SSL certificate created
-          schema:
-            $ref: '#/definitions/SslCertificateRepresentation'
-  '/api/program/{programId}/dv-certificates':
-    post:
-      tags:
-        - SSL Certificates
-      summary: Create DV certificate
-      description: ''
-      operationId: createDvCertificate
-      parameters:
-        - name: programId
-          in: path
-          description: Identifier of the program
-          required: true
-          type: integer
-          format: int64
-        - in: body
-          name: body
-          description: Payload for creating the DV certificate
-          required: true
-          schema:
-            $ref: '#/definitions/CreateDvCertificateBody'
-        - name: x-gw-ims-org-id
-          in: header
-          description: IMS organization ID that the request is being made under.
-          required: true
-          type: string
-        - name: Authorization
-          in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
-          required: true
-          type: string
-        - name: x-api-key
-          in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
-          required: true
-          type: string
-        - name: Content-Type
-          in: header
-          description: Must always be application/json
-          required: true
-          type: string
-      responses:
-        '200':
-          description: successful operation
+          description: Certificate created
           schema:
             $ref: '#/definitions/SslCertificate'
-        '201':
-          description: Created DV certificate
-          schema:
-            $ref: '#/definitions/SslCertificate'
-  '/api/program/{programId}/site/{siteId}':
-    get:
-      tags:
-        - EDS Sites
-      summary: Get Site by Id
-      description: ''
-      operationId: retrieveSite
-      parameters:
-        - name: programId
-          in: path
-          required: true
-          type: string
-        - name: siteId
-          in: path
-          required: true
-          type: integer
-          format: int64
-        - name: x-gw-ims-org-id
-          in: header
-          description: IMS organization ID that the request is being made under.
-          required: true
-          type: string
-        - name: Authorization
-          in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
-          required: true
-          type: string
-        - name: x-api-key
-          in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Site retrieved
-          schema:
-            $ref: '#/definitions/Site'
         '404':
-          description: Site could not be found
-    put:
-      tags:
-        - EDS Sites
-      summary: Update Site
-      description: ''
-      operationId: updateSite
-      parameters:
-        - name: programId
-          in: path
-          required: true
-          type: string
-        - name: siteId
-          in: path
-          required: true
-          type: integer
-          format: int64
-        - name: x-gw-ims-org-id
-          in: header
-          description: IMS organization ID that the request is being made under.
-          required: true
-          type: string
-        - name: Authorization
-          in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
-          required: true
-          type: string
-        - name: x-api-key
-          in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Site updated
-          schema:
-            $ref: '#/definitions/Site'
-        '404':
-          description: Site could not be found
-    delete:
-      tags:
-        - EDS Sites
-      summary: Delete Site
-      description: ''
-      operationId: deleteSite
-      parameters:
-        - name: programId
-          in: path
-          required: true
-          type: string
-        - name: siteId
-          in: path
-          required: true
-          type: integer
-          format: int64
-        - name: x-gw-ims-org-id
-          in: header
-          description: IMS organization ID that the request is being made under.
-          required: true
-          type: string
-        - name: Authorization
-          in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
-          required: true
-          type: string
-        - name: x-api-key
-          in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Site deleted
-          schema:
-            $ref: '#/definitions/Site'
-        '404':
-          description: Site could not be found
-  '/api/program/{programId}/site/{siteId}/validate':
-    put:
-      tags:
-        - EDS Sites
-      summary: Validate Site
-      description: ''
-      operationId: validateSite
-      parameters:
-        - name: programId
-          in: path
-          description: Identifier of the program
-          required: true
-          type: string
-        - name: siteId
-          in: path
-          description: Identifier of the site
-          required: true
-          type: integer
-          format: int64
-        - name: x-gw-ims-org-id
-          in: header
-          description: IMS organization ID that the request is being made under.
-          required: true
-          type: string
-        - name: Authorization
-          in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
-          required: true
-          type: string
-        - name: x-api-key
-          in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Site validated
-          schema:
-            $ref: '#/definitions/Site'
-        '400':
-          description: Site could not be validated. CloudManager challenge does not match
-        '500':
-          description: Internal Server Error
-        '504':
-          description: Site could not be validated in time
-  '/api/program/{programId}/sites':
-    get:
-      tags:
-        - EDS Sites
-      summary: Get All Sites by programId
-      description: ''
-      operationId: getProgramSites
-      parameters:
-        - name: programId
-          in: path
-          required: true
-          type: string
-        - name: x-gw-ims-org-id
-          in: header
-          description: IMS organization ID that the request is being made under.
-          required: true
-          type: string
-        - name: Authorization
-          in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
-          required: true
-          type: string
-        - name: x-api-key
-          in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Sites retrieved
-          schema:
-            $ref: '#/definitions/SiteList'
-    post:
-      tags:
-        - EDS Sites
-      summary: Create Site
-      description: ''
-      operationId: createSite
-      parameters:
-        - name: programId
-          in: path
-          required: true
-          type: string
-        - name: x-gw-ims-org-id
-          in: header
-          description: IMS organization ID that the request is being made under.
-          required: true
-          type: string
-        - name: Authorization
-          in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
-          required: true
-          type: string
-        - name: x-api-key
-          in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
-          required: true
-          type: string
-      responses:
-        '201':
-          description: Site created
-          schema:
-            $ref: '#/definitions/Site'
+          description: Program not found
   '/api/program/{programId}/feedbacks':
     post:
       tags:
@@ -4679,6 +4101,56 @@ paths:
           description: The requester is not authorized to access the resource.
         '404':
           description: Program not found
+  '/api/program/{programId}/contentFlow/checkCompatibility':
+    post:
+      tags:
+        - ContentSets
+      summary: Backflow Compatibility between source and target environments
+      description: Returns the compatibility between source and target environments
+      operationId: checkBackflowCompatibility
+      parameters:
+        - name: programId
+          in: path
+          description: Identifier of the program
+          required: true
+          type: string
+        - in: body
+          name: body
+          description: Program
+          required: true
+          schema:
+            $ref: '#/definitions/CompatibilityCheckInput'
+        - name: x-gw-ims-org-id
+          in: header
+          description: IMS organization ID that the request is being made under.
+          required: true
+          type: string
+        - name: Authorization
+          in: header
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          required: true
+          type: string
+        - name: x-api-key
+          in: header
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          required: true
+          type: string
+        - name: Content-Type
+          in: header
+          description: Must always be application/json
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Big Bear Topology Compatibility Response
+          schema:
+            $ref: '#/definitions/CompatibilityCheckResponse'
+        '400':
+          description: Bad request
+          schema:
+            $ref: '#/definitions/BadRequestError'
+        '404':
+          description: Program not found
   '/api/program/{programId}/contentFlow/{contentFlowId}':
     get:
       tags:
@@ -5026,6 +4498,9 @@ definitions:
           'http://ns.adobe.com/adobecloud/rel/certificates':
             description: The SSL certificates linked to this program.
             $ref: '#/definitions/HalLink'
+          'http://ns.adobe.com/adobecloud/rel/domainNames':
+            description: The domain names linked to this program.
+            $ref: '#/definitions/HalLink'
           'http://ns.adobe.com/adobecloud/rel/tenant':
             description: The tenant this program belongs to
             $ref: '#/definitions/HalLink'
@@ -5205,6 +4680,7 @@ definitions:
           - prod
           - rde
           - preprod
+          - devxl
       steps:
         type: array
         description: 'Steps to be included in the phase in execution order. Might be added or not, depending on permissions or configuration'
@@ -5561,6 +5037,7 @@ definitions:
           - prod
           - rde
           - preprod
+          - devxl
       status:
         type: string
         example: creating
@@ -5579,6 +5056,7 @@ definitions:
           - resetting
           - reset_failed
           - degraded
+          - hibernated
       region:
         type: string
         example: va7
@@ -5896,11 +5374,15 @@ definitions:
         type: string
         example: MY_VAR1
         description: 'Name of the variable. Can only consist of a-z, A-Z, _ and 0-9 and cannot begin with a number.'
+        minLength: 2
+        maxLength: 100
         pattern: '[a-zA-Z_][a-zA-Z_0-9]*'
       value:
         type: string
         example: myValue
         description: 'Value of the variable. Read-Write for non-secrets, write-only for secrets. The length of `secretString` values must be less than 500 characters. An empty value causes a variable to be deleted.'
+        minLength: 0
+        maxLength: 2048
       type:
         type: string
         example: string
@@ -5909,11 +5391,21 @@ definitions:
           - string
           - secretString
       service:
+        type: string
+        example: author
         description: 'Service of the variable. When not provided, the variable applies to all services. Currently the values ''author'', ''publish'', and ''preview'' are supported. Note - this value is case-sensitive.'
       status:
         type: string
         example: ready
         description: Status of the variable
+        enum:
+          - creating
+          - ready
+          - deleting
+          - deleted
+          - updating
+          - failed
+          - deleted_failed
     description: A named value than can be set on an Environment or Pipeline
   VariableList:
     type: object
@@ -5921,6 +5413,7 @@ definitions:
       _totalNumberOfItems:
         type: integer
         format: int32
+        example: 1
         description: The total number of embedded items
       _embedded:
         type: object
@@ -5936,8 +5429,11 @@ definitions:
         type: object
         readOnly: true
         properties:
-          'http://ns.adobe.com/adobecloud/rel/edgeEnvironment':
-            description: The edge environment holding the variables
+          'http://ns.adobe.com/adobecloud/rel/environment':
+            description: The environment holding the variables
+            $ref: '#/definitions/HalLink'
+          'http://ns.adobe.com/adobecloud/rel/pipeline':
+            description: The pipeline holding the variables
             $ref: '#/definitions/HalLink'
           'http://ns.adobe.com/adobecloud/rel/program':
             description: The Program
@@ -5948,16 +5444,75 @@ definitions:
   RegionDeployment:
     type: object
     properties:
-      regionName:
+      cluster:
         type: string
-      clusterName:
+        example: ethos13stageva7
+        description: The cluster where this deployment happens
+      namespace:
         type: string
-      namespaceName:
+        example: ns-team-aem
+        description: The namespace in which this deployment happens
+      createdAt:
         type: string
+        format: date-time
+        description: Created time
+      updatedAt:
+        type: string
+        format: date-time
+        description: Date of last change
+      id:
+        type: string
+        description: identifier of a region deployment
+      environmentId:
+        type: string
+        description: identifier of an environment
+      region:
+        type: string
+        example: va7
+        description: Region name of the deployment
+      integrations:
+        description: region integrations
+        $ref: '#/definitions/EnvironmentRegionintegrations'
+      status:
+        type: string
+        description: Status of the region deployment
+        enum:
+          - PENDING
+          - PROGRESSING
+          - FAILED
+          - COMPLETE
+          - DELETING
+          - DELETED
+          - DELETION_FAILED
+          - TO_DELETE
+          - DEPLOY_FAILED
+          - DEPLOY_TIMEOUT
       type:
         type: string
-      dataStore:
-        $ref: '#/definitions/DataStore'
+        example: primary
+        description: Type of the region deployment
+        enum:
+          - PRIMARY
+          - SECONDARY
+      _links:
+        type: object
+        readOnly: true
+        properties:
+          'http://ns.adobe.com/adobecloud/rel/flow':
+            $ref: '#/definitions/HalLink'
+          'http://ns.adobe.com/adobecloud/rel/kubernetesCluster':
+            description: Get the Kubernetes Cluster in which this deployment happens
+            $ref: '#/definitions/HalLink'
+          'http://ns.adobe.com/adobecloud/rel/kubernetesNamespace':
+            description: Get the Kubernetes Namespace in which this deployment happens
+            $ref: '#/definitions/HalLink'
+          'http://ns.adobe.com/adobecloud/rel/region':
+            description: Region being used for this deployment
+            $ref: '#/definitions/HalLink'
+          self:
+            $ref: '#/definitions/HalLink'
+            description: This object's representation
+    description: describes region deployments for an environment
   RegionDeploymentList:
     type: object
     properties:
@@ -6299,15 +5854,38 @@ definitions:
       name:
         type: string
         description: 'Name of the log for service in environment. Example: aemerror'
-  DataStore:
+  EnvironmentBlobStorageConfiguration:
     type: object
+    required:
+      - type
     properties:
       type:
         type: string
-      blobStorageAccountName:
+        enum:
+          - azure_blob
+          - azure_files
+          - mongo_atlas
+    description: Settings for environment blob storage
+  EnvironmentLogStorageConfiguration:
+    type: object
+    required:
+      - type
+    properties:
+      type:
         type: string
-      blobContainerName:
-        type: string
+        enum:
+          - azure_blob
+          - azure_files
+          - mongo_atlas
+    description: Settings for environment log storage
+  EnvironmentRegionintegrations:
+    type: object
+    properties:
+      blobStorage:
+        $ref: '#/definitions/EnvironmentBlobStorageConfiguration'
+      logStorage:
+        $ref: '#/definitions/EnvironmentLogStorageConfiguration'
+    description: integrations for a particular EnvironmentRegion
   RestorePointDetails:
     type: object
     properties:
@@ -6393,10 +5971,17 @@ definitions:
     properties:
       errorCode:
         type: string
+        description: The error code
         readOnly: true
       publicDetails:
+        type: object
+        description: Additional error details that can be used by customer
+        additionalProperties:
+          type: object
         readOnly: true
       message:
+        type: string
+        description: Human readable error message
         readOnly: true
   Restore-Environmentdetailsrepresentation:
     type: object
@@ -6545,38 +6130,41 @@ definitions:
       - environmentId
     properties:
       id:
-        type: integer
-        format: int64
-        example: 14
+        type: string
+        example: '14'
         description: Identifier of the IP Allowed List Binding to an Environment
       tier:
         type: string
         example: publish
         description: Tier of the environment.
         enum:
-          - PUBLISH
-          - PREVIEW
-          - AUTHOR
-          - STATIC
-          - DELIVERY
+          - author
+          - publish
+          - preview
+          - delivery
       status:
         type: string
         example: NOT_STARTED
         description: Status of the binding.
+        enum:
+          - failed
+          - delete_failed
+          - running
+          - deleting
+          - completed
+          - deleted
+          - not_started
       programId:
-        type: integer
-        format: int64
-        example: 22
+        type: string
+        example: '22'
         description: Identifier of the program.
       ipAllowListId:
-        type: integer
-        format: int64
-        example: 17
+        type: string
+        example: '17'
         description: Identifier of the IP allow list.
       environmentId:
-        type: integer
-        format: int64
-        example: 5
+        type: string
+        example: '5'
         description: Identifier of the environment.
       _links:
         type: object
@@ -6599,19 +6187,15 @@ definitions:
       - name
     properties:
       id:
-        type: integer
-        format: int64
-        example: 14
+        type: string
+        example: '14'
         description: Identifier of the IP Allowed List
       name:
         type: string
         example: NewYork Office
         description: Name of the IP Allowed List
-      programId:
-        type: integer
-        format: int64
-        example: 22
-        description: Identifier of the program.
+        minLength: 1
+        maxLength: 64
       ipCidrSet:
         type: array
         example: '["11.22.33.44/28", "99.88.77.66/32"]'
@@ -6621,6 +6205,10 @@ definitions:
           type: string
         maxItems: 50
         minItems: 1
+      programId:
+        type: string
+        example: '22'
+        description: Identifier of the program.
       bindings:
         type: array
         description: IP Allowlist bindings
@@ -6639,25 +6227,6 @@ definitions:
             $ref: '#/definitions/HalLink'
             description: This object's representation
     description: Describes an __IP Allowed List__
-  Updateanipallowlist:
-    type: object
-    required:
-      - ipCidrSet
-      - name
-    properties:
-      name:
-        type: string
-        example: NewYork Office
-        description: Name of the IP Allowed List
-      ipCidrSet:
-        type: array
-        example: '["11.22.33.44/28", "99.88.77.66/32"]'
-        description: IP CIDR Set
-        uniqueItems: true
-        items:
-          type: string
-        maxItems: 50
-        minItems: 1
   IPAllowlistBindingsList:
     type: object
     properties:
@@ -6665,8 +6234,6 @@ definitions:
         type: integer
         format: int32
         description: The total number of embedded items
-      ipAllowlistId:
-        type: string
       _embedded:
         type: object
         readOnly: true
@@ -6716,356 +6283,122 @@ definitions:
           self:
             $ref: '#/definitions/HalLink'
             description: This object's representation
-  Createanewipallowlist:
+  DomainNameTargetRepresentation:
     type: object
-    required:
-      - ipCidrSet
-      - name
     properties:
-      name:
+      target:
         type: string
-        example: NewYork Office
-        description: Name of the IP Allowed List
-      ipCidrSet:
-        type: array
-        example: '["11.22.33.44/28", "99.88.77.66/32"]'
-        description: IP CIDR Set
-        uniqueItems: true
-        items:
-          type: string
-        maxItems: 50
-        minItems: 1
-  Domain:
+        description: IP or domain name which the domain name points to.
+      detected:
+        type: boolean
+        description: Flag that shows if the target was detected or not.
+        default: false
+  DomainName:
     type: object
     required:
-      - label
-      - programId
+      - certificateId
     properties:
-      deleted:
-        type: boolean
-        default: false
       id:
         type: integer
         format: int64
         description: id
-      domainName:
+      name:
         type: string
         example: customer.domain.com
         description: Name of the domain name
-      label:
+      status:
         type: string
-        description: Domain label
-      programId:
+        example: ready
+        description: Status of the domain name
+        enum:
+          - not_verified
+          - pending_deployment
+          - deployment_failed
+          - deployed
+          - pending_readiness_check
+          - ready
+          - deleting
+          - deleted
+          - delete_failed
+      type:
+        type: string
+        example: CNAME
+        description: Type of the domain name record
+        enum:
+          - A
+          - CNAME
+      dnsResolution:
+        type: array
+        description: Pointing IPs/domain name
+        items:
+          $ref: '#/definitions/DomainNameTargetRepresentation'
+      dnsTxtRecord:
+        type: string
+        example: adobe-aem-verification=www.adobe.com/1/2/ab-cd-ef
+        description: DNS TXT record
+      dnsZone:
+        type: string
+        example: adobe.com.
+        description: Name of the DNS zone
+      environmentId:
         type: integer
         format: int64
-        description: Id of the program
+        description: environmentId
+      environmentName:
+        type: string
+        example: customerEnvironmentName
+        description: Environment name
+      tier:
+        type: string
+        example: publish
+        description: Tier of the environment.
+        enum:
+          - publish
+          - preview
+      certificateId:
+        type: integer
+        format: int64
+        description: certificateId
+      certificateName:
+        type: string
+        example: My certificate
+        description: SSL Certificate name
+      certificateExpireAt:
+        type: string
+        format: date-time
+        description: SSL Certificate expiration date
       createdAt:
-        type: integer
-        format: int64
+        type: string
+        format: date-time
         description: Create date
       updatedAt:
-        type: integer
-        format: int64
-        description: Last updated date
-      deletedAt:
-        type: integer
-        format: int64
-        description: Deleted At
-      acmeValidationStatus:
         type: string
-        example: NOT_VERIFIED
-        description: Acme Validation Status
-      adobeValidationStatus:
-        type: string
-        example: NOT_VERIFIED
-        description: Adobe Validation Status
-      acmeValidationToken:
-        type: string
-        description: Acme Validation Token
-      adobeValidationToken:
-        type: string
-        description: Adobe Validation Token
-    description: A Domain representation
-  UpdateaDomain'snameorlabel:
-    type: object
-    required:
-      - label
-    properties:
-      label:
-        type: string
-        example: '???'
-        description: Domain label
-  Response:
-    type: object
-    properties:
-      status:
-        type: integer
-        format: int32
-      entity:
-        type: object
-      metadata:
-        type: object
-        additionalProperties:
-          type: array
-          items:
-            type: object
-  DomainCreate:
-    type: object
-    properties:
-      domainName:
-        type: string
-        example: customer.domain.com
-        description: Name of the domain name
-    description: A Domain representation for creating a domain
-  DomainTokenValidationBody:
-    type: object
-    properties:
-      validationType:
-        type: string
-        example: acme
-        description: Type of the validation
-    description: The json body for token validation
-  DomainMapping:
-    type: object
-    properties:
-      domainMappingId:
-        type: integer
-        format: int64
-        description: Domain Mapping ID
-      programId:
-        type: integer
-        format: int64
-        description: Identifier of the CM Program
-      originId:
-        type: integer
-        format: int64
-        description: Id of either EDS site or Skyline Environment
-      domainMappingStatus:
-        type: string
-        description: Status of the domain mapping
-      domainName:
-        type: string
-        description: Name of the domain
-      originType:
-        type: string
-        description: 'Type of origin: EDS_SITE or SKYLINE_ENVIRONMENT'
-      tier:
-        type: string
-        description: 'Type of tier: PREVIEW or PUBLISH'
-        enum:
-          - PUBLISH
-          - PREVIEW
-          - AUTHOR
-          - STATIC
-          - DELIVERY
-      domainId:
-        type: integer
-        format: int64
-        description: Id of the domain
-      certificateId:
-        type: integer
-        format: int64
-        description: Id of the certificate
-      createdAt:
-        type: integer
-        format: int64
-        description: Creation date
-      updatedAt:
-        type: integer
-        format: int64
-        description: Last modification date
-      deletedAt:
-        type: integer
-        format: int64
-        description: Deletion date
-    description: Describes a domain mapping
-  Updateadomainmapping:
-    type: object
-    required:
-      - certificateId
-      - tier
-    properties:
-      certificateId:
-        type: integer
-        format: int64
-        description: Certificate ID
-      tier:
-        type: string
-        description: 'Type of tier: PREVIEW or PUBLISH'
-        enum:
-          - PUBLISH
-          - PREVIEW
-          - AUTHOR
-          - STATIC
-          - DELIVERY
-  DomainMappingList:
-    type: object
-    properties:
-      totalNumberOfItems:
-        type: integer
-        format: int32
-      domainMappings:
-        type: array
-        items:
-          $ref: '#/definitions/DomainMapping'
-  Createanewdomainmapping:
-    type: object
-    required:
-      - certificateId
-      - domainId
-      - originId
-      - originType
-      - tier
-    properties:
-      originId:
-        type: integer
-        format: int64
-        description: 'Origin ID: EDS or Skyline Environment ID'
-      domainId:
-        type: integer
-        format: int64
-        description: Domain ID
-      certificateId:
-        type: integer
-        format: int64
-        description: Certificate ID
-      tier:
-        type: string
-        description: 'Type of the tier: PREVIEW or PUBLISH'
-        enum:
-          - PUBLISH
-          - PREVIEW
-          - AUTHOR
-          - STATIC
-          - DELIVERY
-      originType:
-        type: string
-        description: 'Type of the origin: EDS_SITE or SKYLINE_ENVIRONMENT'
-        enum:
-          - EDS_SITE
-          - SKYLINE_ENVIRONMENT
-  SslCertificateRepresentation:
-    type: object
-    properties:
-      id:
-        type: integer
-        format: int64
-        description: id
-      programId:
-        type: integer
-        format: int64
-        example: 14
-        description: Identifier of the application. Unique within the space.
-      serialNumber:
-        type: string
-        description: Unique identifier of the certificate at CA level.
-      name:
-        type: string
-        example: Certificate Name Example
-        description: Name of the SSL Certificate.
-      issuer:
-        type: string
-        description: Issuer of the SSL Certificate.
-      expireAt:
-        type: integer
-        format: int64
-        description: Expiration date of the SSL Certificate.
-      commonName:
-        type: string
-        description: Common name of the SSL Certificate.
-      subjectAlternativeNames:
-        type: array
-        description: Subject alternative names of the SSL Certificate.
-        items:
-          type: string
-      certificate:
-        type: string
-        description: Encrypted content of the SSL Certificate.
-      chain:
-        type: string
-        description: Content of the Chain File.
-      createdAt:
-        type: integer
-        format: int64
-        description: Date of SSL Certificate submission.
-      updatedAt:
-        type: integer
-        format: int64
-        description: Date of last SSL Certificate update.
+        format: date-time
+        description: Update date
       _links:
         type: object
         readOnly: true
         properties:
+          'http://ns.adobe.com/adobecloud/rel/domainName/certificates':
+            description: SSL certificates in program
+            $ref: '#/definitions/HalLink'
+          'http://ns.adobe.com/adobecloud/rel/domainName/deploy':
+            description: Trigger DNS TXT record verification and start CDN deployment
+            $ref: '#/definitions/HalLink'
+          'http://ns.adobe.com/adobecloud/rel/domainName/verify':
+            description: Trigger DNS route verification of the domain name
+            $ref: '#/definitions/HalLink'
+          'http://ns.adobe.com/adobecloud/rel/environment':
+            description: The environment holding the domain name
+            $ref: '#/definitions/HalLink'
+          'http://ns.adobe.com/adobecloud/rel/program':
+            description: The Application this domain name belongs to.
+            $ref: '#/definitions/HalLink'
           self:
             $ref: '#/definitions/HalLink'
             description: This object's representation
-    description: Describes an SSL Certificate
-  StackTraceElement:
-    type: object
-    properties:
-      classLoaderName:
-        type: string
-      moduleName:
-        type: string
-      moduleVersion:
-        type: string
-      methodName:
-        type: string
-      fileName:
-        type: string
-      lineNumber:
-        type: integer
-        format: int32
-      className:
-        type: string
-      nativeMethod:
-        type: boolean
-        default: false
-  SslCertificateNotFoundException:
-    type: object
-    properties:
-      stackTrace:
-        type: array
-        items:
-          $ref: '#/definitions/StackTraceElement'
-      message:
-        type: string
-      localizedMessage:
-        type: string
-  SecretString:
-    type: object
-    properties:
-      value:
-        type: string
-        example: my-secret
-        description: 'Secret value for updating the secrets, null for not updating the existing secret'
-      path:
-        type: string
-        example: /path/to/secret
-        description: Path to the secret value
-  CreateOrUpdateSslCertificateBody:
-    type: object
-    required:
-      - name
-      - certificate
-      - privateKey
-      - chain
-    properties:
-      name:
-        type: string
-        description: The name of the new SSL Certificate.
-      certifcate:
-        type: string
-        description: The PEM-encoded certificate.
-      privateKey:
-        type: string
-        description: The PEM-encoded private key.
-      chain:
-        type: array
-        items:
-          type: string
-        description: The PEM-encoded certificate chain.
-  AllSSLCertificatesList:
+    description: A Domain Name representation
+  DomainNameList:
     type: object
     properties:
       _totalNumberOfItems:
@@ -7079,10 +6412,10 @@ definitions:
         type: object
         readOnly: true
         properties:
-          certificates:
+          domainNames:
             type: array
             items:
-              $ref: '#/definitions/SslCertificateRepresentation'
+              $ref: '#/definitions/DomainName'
       _links:
         type: object
         readOnly: true
@@ -7099,119 +6432,56 @@ definitions:
           self:
             $ref: '#/definitions/HalLink'
             description: This object's representation
-  CreateDvCertificateBody:
-    type: object
-    required:
-      - domainIds
-    properties:
-      name:
-        type: string
-        example: my-cert
-        description: Name of the certificate
-      domainIds:
-        type: array
-        description: List of domain IDs to associate with the certificate
-        items:
-          type: integer
-          format: int64
   SslCertificate:
     type: object
     properties:
       id:
-        type: integer
-        format: int64
-      sslCertificateType:
         type: string
-        enum:
-          - DV
-          - EV
-          - OV
+        description: id
       programId:
-        type: integer
-        format: int64
+        type: string
+        example: '14'
+        description: Identifier of the application. Unique within the space.
       serialNumber:
         type: string
+        description: Unique identifier of the certificate at CA level.
       name:
         type: string
-      certificate:
-        type: string
+        example: Certificate Name Example
+        description: Name of the SSL Certificate.
       issuer:
         type: string
+        description: Issuer of the SSL Certificate.
       expireAt:
-        type: integer
-        format: int64
-      privateKeyPath:
         type: string
+        format: date-time
+        description: Expiration date of the SSL Certificate.
       commonName:
         type: string
-      commonNameRegex:
-        type: string
+        description: Common name of the SSL Certificate.
       subjectAlternativeNames:
         type: array
+        description: Subject alternative names of the SSL Certificate.
         items:
           type: string
-      subjectAlternativeNamesRegex:
+      attachedDomainNames:
         type: array
+        description: Attached domain names
         items:
           type: string
-      chain:
-        type: string
+      attachedEnvironmentNames:
+        type: array
+        description: Attached environment names
+        items:
+          type: string
       createdAt:
-        type: integer
-        format: int64
+        type: string
+        format: date-time
+        description: Date of SSL Certificate submission.
       updatedAt:
-        type: integer
-        format: int64
-      deletedAt:
-        type: integer
-        format: int64
-      externalId:
-        type: integer
-        format: int64
-      sslCertificateStatus:
         type: string
-        enum:
-          - PENDING
-          - VALID
-          - EXPIRED
-  Site:
-    type: object
-    properties:
-      siteId:
-        type: integer
-        format: int64
-        description: siteId
-      programId:
-        type: string
-        description: Identifier of the CM Program ID. Unique within the space.
-      siteName:
-        type: string
-        description: Name of the site
-      repoUrl:
-        type: string
-        description: CM Eds Site Repo URL.
-      siteStatus:
-        type: string
-        description: Site EDS status
-      validationToken:
-        type: string
-        description: Validation token of the CM EDS Site
-      createdAt:
-        type: integer
-        format: int64
-        description: Creation date
-      modifiedAt:
-        type: integer
-        format: int64
-        description: Last modification date
-      deletedAt:
-        type: integer
-        format: int64
-        description: Deleted date
-      deleted:
-        type: boolean
-        description: deleted or not
-        default: false
+        format: date-time
+        description: Date of last SSL Certificate update.
       _links:
         type: object
         readOnly: true
@@ -7219,28 +6489,38 @@ definitions:
           self:
             $ref: '#/definitions/HalLink'
             description: This object's representation
-          sites:
-            $ref: '#/definitions/HalLink'
-    description: Describes a Site
-  SiteList:
+    description: Describes an SSL Certificate
+  CertificatesList:
     type: object
     properties:
       _totalNumberOfItems:
         type: integer
         format: int32
         description: The total number of embedded items
+      _page:
+        $ref: '#/definitions/RequestedPageDetails'
+        description: Details of the requested page of items
       _embedded:
         type: object
         readOnly: true
         properties:
-          sites:
+          certificates:
             type: array
             items:
-              $ref: '#/definitions/Site'
+              $ref: '#/definitions/SslCertificate'
       _links:
         type: object
         readOnly: true
         properties:
+          next:
+            $ref: '#/definitions/HalLink'
+            description: The next page of results.
+          page:
+            $ref: '#/definitions/HalLink'
+            description: An arbitrary page of results.
+          prev:
+            $ref: '#/definitions/HalLink'
+            description: The previous page of results.
           self:
             $ref: '#/definitions/HalLink'
             description: This object's representation
@@ -7850,6 +7130,77 @@ definitions:
         description: copyVersions
         default: false
     description: Wraps the content flow execution arguments
+  CompatibilityCheckInput:
+    type: object
+    required:
+      - destinationEnvironmentId
+      - sourceEnvironmentId
+    properties:
+      sourceEnvironmentId:
+        type: string
+      destinationEnvironmentId:
+        type: string
+      tier:
+        type: string
+        enum:
+          - PUBLISH
+          - AUTHOR
+    description: Wraps the content copy compatibility check execution arguments.
+  CompatibilityCheckResponse:
+    type: object
+    properties:
+      sourceEnvironmentId:
+        type: string
+        example: '1234'
+        description: The source environment ID
+      sourceTopologyId:
+        type: string
+        example: 1a2b3cd4
+        description: The source topology ID
+      destinationEnvironmentId:
+        type: string
+        example: '5678'
+        description: The destination environment ID
+      destinationTopologyId:
+        type: string
+        example: 1a2b3cd4
+        description: The destination topology ID
+      tier:
+        type: string
+        example: author
+        description: tier
+      overallResult:
+        type: string
+        example: PASS
+        description: The overall result of the compatibility check
+      overallMessage:
+        type: string
+        example: Destination Topology cannot be prod.
+        description: The overall response message of the compatibility check
+      failedValidation:
+        type: string
+        example: TIER_NOT_ALLOWED
+        description: Error Code for the Failed Compatibility Check
+        enum:
+          - SOURCE_DISK_ORG
+          - TARGET_DISK_ORG
+          - SOURCE_REPO_TYPE
+          - TARGET_REPO_TYPE
+          - DATASTORE_TYPE
+          - BLOCK_TYPE
+          - TARGET_ENV
+          - REGION_CRITERIA
+          - CONNECTION_ERROR
+          - UNSUPPORTED_SKYLINE_ENV
+          - BAD_REQUEST
+          - ENVIRONMENT_NOT_FOUND
+          - PROGRAM_NOT_FOUND
+          - TIER_NOT_ALLOWED
+          - UNKNOWN
+      responseStatusCode:
+        type: integer
+        format: int32
+    description: Describes the Backflow Compatibility between two topologies.
   ContentFlowLog:
     type: object
     properties:
@@ -7882,6 +7233,28 @@ definitions:
       redirect:
         type: string
         description: The url to redirect to.
+  NewSslCertificate:
+    type: object
+    required:
+      - name
+      - certificate
+      - privateKey
+      - chain
+    properties:
+      name:
+        type: string
+        description: The name of the new SSL Certificate.
+      certifcate:
+        type: string
+        description: The PEM-encoded certificate.
+      privateKey:
+        type: string
+        description: The PEM-encoded private key.
+      chain:
+        type: array
+        items:
+          type: string
+        description: The PEM-encoded certificate chain.
   NewFeedback:
     type: object
     required:
@@ -7935,11 +7308,15 @@ definitions:
         type: string
         example: MY_VAR1
         description: 'Name of the variable. Can only consist of a-z, A-Z, _ and 0-9 and cannot begin with a number.'
+        minLength: 2
+        maxLength: 100
         pattern: '[a-zA-Z_][a-zA-Z_0-9]*'
       value:
         type: string
         example: myValue
         description: 'Value of the variable. Read-Write for non-secrets, write-only for secrets. The length of `secretString` values must be less than 500 characters. An empty value causes a variable to be deleted.'
+        minLength: 0
+        maxLength: 2048
       type:
         type: string
         example: string
@@ -7948,6 +7325,8 @@ definitions:
           - string
           - secretString
       service:
+        type: string
+        example: author
         description: 'Service of the variable. When not provided, the variable applies to all services. Currently the values ''author'', ''publish'', and ''preview'' are supported. Note - this value is case-sensitive.'
     description: 'A change (create, update, delete) of a named value on an Environment'
   PipelineVariableUpdate:
@@ -7957,11 +7336,15 @@ definitions:
         type: string
         example: MY_VAR1
         description: 'Name of the variable. Can only consist of a-z, A-Z, _ and 0-9 and cannot begin with a number.'
+        minLength: 2
+        maxLength: 100
         pattern: '[a-zA-Z_][a-zA-Z_0-9]*'
       value:
         type: string
         example: myValue
         description: 'Value of the variable. Read-Write for non-secrets, write-only for secrets. The length of `secretString` values must be less than 500 characters. An empty value causes a variable to be deleted.'
+        minLength: 0
+        maxLength: 2048
       type:
         type: string
         example: string
@@ -8193,6 +7576,56 @@ definitions:
         type: string
         example: TO_DELETE
         description: Status of the region deployment to be set
+  DomainNameValidate:
+    type: object
+    description: Description of a domain name to validate
+    required:
+      - name
+      - environmentId
+      - certificateId
+    properties:
+      name:
+        type: string
+        example: customer.domain.com
+        description: Name of the domain name
+      environmentId:
+        type: integer
+        format: int64
+        description: The environment id
+      certificateId:
+        type: integer
+        format: int64
+        description: The certificate id
+  NewDomainName:
+    type: object
+    description: Description of a domain name to create
+    required:
+      - name
+      - environmentId
+      - certificateId
+      - dnsTxtRecord
+      - dnsZone
+    properties:
+      name:
+        type: string
+        example: customer.domain.com
+        description: Name of the domain name
+      environmentId:
+        type: integer
+        format: int64
+        description: The environment id
+      certificateId:
+        type: integer
+        format: int64
+        description: The certificate id
+      dnsTxtRecord:
+        type: string
+        example: adobe-aem-verification=www.adobe.com/1/2/ab-cd-ef
+        description: DNS TXT record. Must match the corresponding record returned from the validate request.
+      dnsZone:
+        type: string
+        example: adobe.com.
+        description: Name of the DNS zone. Must match the corresponding value returned from the validate request.
   NewRelicSubAccountUser:
     type: object
     properties:

--- a/swagger-specs/api.yaml
+++ b/swagger-specs/api.yaml
@@ -2616,7 +2616,7 @@ paths:
             $ref: '#/definitions/Domain'
         '404':
           description: Domain not found
-      put:
+    put:
       tags:
         - Domain
       summary: Update domain
@@ -2703,7 +2703,7 @@ paths:
           description: Domain deleted
           schema:
             $ref: '#/definitions/Response'
-            '/api/program/{programId}/domain/{domain-id}/validate':
+  '/api/program/{programId}/domain/{domain-id}/validate':
     put:
       tags:
         - Domain
@@ -2831,10 +2831,10 @@ paths:
           required: true
           type: string
         - name: Authorization
-            in: header
-            description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
-            required: true
-            type: string
+          in: header
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          required: true
+          type: string
         - name: x-api-key
           in: header
           description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
@@ -2856,7 +2856,7 @@ paths:
       parameters:
         - name: programId
           in: path
-            description: Identifier of program
+          description: Identifier of program
           required: true
           type: integer
           format: int64

--- a/swagger-specs/api.yaml
+++ b/swagger-specs/api.yaml
@@ -3016,54 +3016,54 @@ paths:
           description: List of domain mappings retrieved
           schema:
             $ref: '#/definitions/DomainMappingList'
-      post:
-        tags:
-          - Domain Mappings - CDN Configurations
-        summary: Create domain mapping
-        description: ''
-        operationId: createDomainMapping
-        parameters:
-          - name: programId
-            in: path
-            description: Identifier of program
-            required: true
-            type: integer
-            format: int64
-          - in: body
-            name: body
-            description: Payload for creating a domain mapping
-            required: true
-            schema:
-              $ref: '#/definitions/Createanewdomainmapping'
-          - name: x-gw-ims-org-id
-            in: header
-            description: IMS organization ID that the request is being made under.
-            required: true
-            type: string
-          - name: Authorization
-            in: header
-            description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
-            required: true
-            type: string
-          - name: x-api-key
-            in: header
-            description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
-            required: true
-            type: string
-          - name: Content-Type
-            in: header
-            description: Must always be application/json
-            required: true
-            type: string
-        responses:
-          '200':
-            description: successful operation
-            schema:
-              $ref: '#/definitions/DomainMapping'
-          '201':
-            description: Domain Mapping created
-            schema:
-              $ref: '#/definitions/DomainMapping'
+    post:
+      tags:
+        - Domain Mappings - CDN Configurations
+      summary: Create domain mapping
+      description: ''
+      operationId: createDomainMapping
+      parameters:
+        - name: programId
+          in: path
+          description: Identifier of program
+          required: true
+          type: integer
+          format: int64
+        - in: body
+          name: body
+          description: Payload for creating a domain mapping
+          required: true
+          schema:
+            $ref: '#/definitions/Createanewdomainmapping'
+        - name: x-gw-ims-org-id
+          in: header
+          description: IMS organization ID that the request is being made under.
+          required: true
+          type: string
+        - name: Authorization
+          in: header
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          required: true
+          type: string
+        - name: x-api-key
+          in: header
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          required: true
+          type: string
+        - name: Content-Type
+          in: header
+          description: Must always be application/json
+          required: true
+          type: string
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            $ref: '#/definitions/DomainMapping'
+        '201':
+          description: Domain Mapping created
+          schema:
+            $ref: '#/definitions/DomainMapping'
   '/api/program/{programId}/environment/{environmentId}/domain-mappings':
     get:
       tags:

--- a/swagger-specs/api.yaml
+++ b/swagger-specs/api.yaml
@@ -2,7 +2,7 @@ swagger: '2.0'
 info:
   version: 1.0.0
   title: Cloud Manager API
-  description: 'This API allows access to Cloud Manager programs, pipelines, and environments by an authorized technical account created through the Adobe I/O Console. The base url for this API is https://cloudmanager.adobe.io, e.g. to get the list of programs for an organization, you would make a GET request to https://cloudmanager.adobe.io/api/programs (with the correct set  of headers as described below). This swagger file can be downloaded from https://raw.githubusercontent.com/AdobeDocs/cloudmanager-api-docs/main/swagger-specs/api.yaml.'
+  description: 'This API allows access to Cloud Manager programs, pipelines, and environments by an authorized technical account created through the Adobe I/O Console. The base url for this API is https://cloudmanager.adobe.io, e.g. to get the list of programs for an organization, you would make a GET request to https://cloudmanager.adobe.io/api/programs (with the correct set of headers as described below). This swagger file can be downloaded from https://raw.githubusercontent.com/AdobeDocs/cloudmanager-api-docs/main/swagger-specs/api.yaml.'
 host: cloudmanager.adobe.io
 schemes:
   - https
@@ -24,13 +24,13 @@ tags:
   - name: Environment Restore From Backup
   - name: IP Allowlist
   - name: IP Allowlist Binding
-  - name: Domain Names
-  - name: SSLCertificates
+  - name: Domain
+  - name: Domain Mappings - CDN Configurations
+  - name: SSL Certificates
+  - name: EDS Sites
   - name: Tenants
   - name: Regions
   - name: Network infrastructure
-  - name: Environment Advanced Networking Configuration
-  - name: ContentSets
   - name: Environment Advanced Networking Configuration
   - name: ContentSets
 paths:
@@ -39,10 +39,7 @@ paths:
       tags:
         - Programs
       summary: Lists Programs
-      description: >-
-        This API is deprecated and should no longer be used. Please use the
-        [Lists Programs for Tenant API](#operation/getProgramsForTenant)
-        instead.
+      description: 'This API is deprecated and should no longer be used. Please use the [Lists Programs for Tenant API](#operation/getProgramsForTenant) instead.'
       operationId: getPrograms
       parameters:
         - name: x-gw-ims-org-id
@@ -52,16 +49,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -69,7 +62,7 @@ paths:
           description: successful operation
           schema:
             $ref: '#/definitions/ProgramList'
-  /api/program/{programId}:
+  '/api/program/{programId}':
     get:
       tags:
         - Programs
@@ -89,16 +82,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -127,16 +116,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -154,7 +139,7 @@ paths:
           description: Program not found.
         '412':
           description: Deletion not supported
-  /api/program/{programId}/repositories:
+  '/api/program/{programId}/repositories':
     get:
       tags:
         - Repositories
@@ -187,16 +172,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -204,7 +185,7 @@ paths:
           description: successful operation
           schema:
             $ref: '#/definitions/RepositoryList'
-  /api/program/{programId}/repository/{repositoryId}:
+  '/api/program/{programId}/repository/{repositoryId}':
     get:
       tags:
         - Repositories
@@ -229,16 +210,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -246,7 +223,7 @@ paths:
           description: successful operation
           schema:
             $ref: '#/definitions/Repository'
-  /api/program/{programId}/repository/{repositoryId}/branches:
+  '/api/program/{programId}/repository/{repositoryId}/branches':
     get:
       tags:
         - Branches
@@ -271,16 +248,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -288,14 +261,12 @@ paths:
           description: Successful retrieval of the list of repository branches
           schema:
             $ref: '#/definitions/BranchList'
-  /api/program/{programId}/pipelines:
+  '/api/program/{programId}/pipelines':
     get:
       tags:
         - Pipelines
       summary: List Pipelines
-      description: >-
-        Returns all the pipelines that the requesting user has access to in an
-        program
+      description: Returns all the pipelines that the requesting user has access to in an program
       operationId: getPipelines
       parameters:
         - name: programId
@@ -328,16 +299,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -345,7 +312,7 @@ paths:
           description: successful operation
           schema:
             $ref: '#/definitions/PipelineList'
-  /api/program/{programId}/pipeline/{pipelineId}:
+  '/api/program/{programId}/pipeline/{pipelineId}':
     get:
       tags:
         - Pipelines
@@ -370,16 +337,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -413,16 +376,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -458,16 +417,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -480,7 +435,7 @@ paths:
           description: successful operation
           schema:
             $ref: '#/definitions/Pipeline'
-  /api/program/{programId}/pipeline/{pipelineId}/cache:
+  '/api/program/{programId}/pipeline/{pipelineId}/cache':
     delete:
       tags:
         - Pipelines
@@ -505,22 +460,18 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
         default:
           description: successful operation
-  /api/program/{programId}/pipeline/{pipelineId}/execution:
+  '/api/program/{programId}/pipeline/{pipelineId}/execution':
     get:
       tags:
         - Pipeline Execution
@@ -545,16 +496,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -568,9 +515,7 @@ paths:
       tags:
         - Pipeline Execution
       summary: Start the pipeline
-      description: >-
-        Starts the Pipeline. This works only if the pipeline is not already
-        started.
+      description: Starts the Pipeline. This works only if the pipeline is not already started.
       operationId: startPipeline
       parameters:
         - name: programId
@@ -585,9 +530,7 @@ paths:
           type: string
         - name: pipelineExecutionMode
           in: query
-          description: >-
-            The mode in which to run the execution. EMERGENCY mode will skip
-            certain steps and is only available to select AMS customers.
+          description: The mode in which to run the execution. EMERGENCY mode will skip certain steps and is only available to select AMS customers.
           required: false
           type: string
           default: NORMAL
@@ -601,9 +544,7 @@ paths:
           type: string
         - name: sourceExecutionId
           in: query
-          description: >-
-            Identifier of the source execution from which the execution will
-            start
+          description: Identifier of the source execution from which the execution will start
           required: false
           type: string
         - name: x-gw-ims-org-id
@@ -613,16 +554,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -646,12 +583,10 @@ paths:
         '412':
           description: Pipeline is busy
         '503':
-          description: >-
-            Pipeline execution cannot be started because of unplanned
-            maintenance
+          description: Pipeline execution cannot be started because of unplanned maintenance
           schema:
             $ref: '#/definitions/SystemUnderMaintenanceExceptionMapper'
-  /api/program/{programId}/pipeline/{pipelineId}/execution/{executionId}:
+  '/api/program/{programId}/pipeline/{pipelineId}/execution/{executionId}':
     get:
       tags:
         - Pipeline Execution
@@ -681,16 +616,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -700,7 +631,7 @@ paths:
             $ref: '#/definitions/PipelineExecution'
         '404':
           description: No pipeline execution exits or unknown pipeline or application
-  /api/program/{programId}/pipeline/{pipelineId}/execution/{executionId}/phase/{phaseId}/step/{stepId}:
+  '/api/program/{programId}/pipeline/{pipelineId}/execution/{executionId}/phase/{phaseId}/step/{stepId}':
     get:
       tags:
         - Pipeline Execution
@@ -740,16 +671,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -761,16 +688,12 @@ paths:
           description: Missing permission for user to read step
         '404':
           description: Pipeline execution does not exist
-  /api/program/{programId}/pipeline/{pipelineId}/execution/{executionId}/phase/{phaseId}/step/{stepId}/advance:
+  '/api/program/{programId}/pipeline/{pipelineId}/execution/{executionId}/phase/{phaseId}/step/{stepId}/advance':
     put:
       tags:
         - Pipeline Execution
       summary: Advance
-      description: >-
-        Post to this url in order to advance the current pipeline execution, if
-        paused and waiting for user interaction. Link is present in output only
-        in that case. The input depends on the actual reason for which the
-        pipeline execution stopped.
+      description: 'Post to this url in order to advance the current pipeline execution, if paused and waiting for user interaction. Link is present in output only in that case. The input depends on the actual reason for which the pipeline execution stopped.'
       operationId: advancePipelineExecution
       parameters:
         - name: programId
@@ -800,10 +723,7 @@ paths:
           type: string
         - in: body
           name: body
-          description: >-
-            Input for advance. See documentation at
-            https://www.adobe.io/experience-cloud/cloud-manager/guides/api-usage/advancing-and-cancelling-steps/
-            for details.
+          description: 'Input for advance. See documentation at https://www.adobe.io/experience-cloud/cloud-manager/guides/api-usage/advancing-and-cancelling-steps/ for details.'
           required: true
           schema:
             type: object
@@ -814,16 +734,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -838,14 +754,12 @@ paths:
           description: Missing permission for user to advance the pipeline execution
         '404':
           description: No pipeline execution exits or unknown pipeline or program
-  /api/program/{programId}/pipeline/{pipelineId}/execution/{executionId}/phase/{phaseId}/step/{stepId}/cancel:
+  '/api/program/{programId}/pipeline/{pipelineId}/execution/{executionId}/phase/{phaseId}/step/{stepId}/cancel':
     put:
       tags:
         - Pipeline Execution
       summary: Cancel
-      description: >-
-        Post to this url in order to cancel the current pipeline execution. Link
-        is present in output only in that case.
+      description: Post to this url in order to cancel the current pipeline execution. Link is present in output only in that case.
       operationId: cancelPipelineExecutionStep
       parameters:
         - name: programId
@@ -875,10 +789,7 @@ paths:
           type: string
         - in: body
           name: body
-          description: >-
-            Input for cancel. See documentation at
-            https://www.adobe.io/experience-cloud/cloud-manager/guides/api-usage/advancing-and-cancelling-steps/
-            for details.
+          description: 'Input for cancel. See documentation at https://www.adobe.io/experience-cloud/cloud-manager/guides/api-usage/advancing-and-cancelling-steps/ for details.'
           required: true
           schema:
             type: object
@@ -889,16 +800,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -913,7 +820,7 @@ paths:
           description: Missing permission for user to cancel the current pipeline execution
         '404':
           description: No pipeline execution exits or unknown pipeline or program
-  /api/program/{programId}/pipeline/{pipelineId}/execution/{executionId}/phase/{phaseId}/step/{stepId}/logs:
+  '/api/program/{programId}/pipeline/{pipelineId}/execution/{executionId}/phase/{phaseId}/step/{stepId}/logs':
     get:
       tags:
         - Pipeline Execution
@@ -955,10 +862,7 @@ paths:
           in: header
           required: false
           type: string
-          description: >-
-            Specify application/json in this header to receive a JSON response.
-            Otherwise, a 307 response code will be returned with a Location
-            header.
+          description: 'Specify application/json in this header to receive a JSON response. Otherwise, a 307 response code will be returned with a Location header.'
         - name: x-gw-ims-org-id
           in: header
           description: IMS organization ID that the request is being made under.
@@ -966,16 +870,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -987,7 +887,7 @@ paths:
           description: Missing permission for user to read logs
         '404':
           description: Pipeline execution does not exist
-  /api/program/{programId}/pipeline/{pipelineId}/execution/{executionId}/phase/{phaseId}/step/{stepId}/artifacts:
+  '/api/program/{programId}/pipeline/{pipelineId}/execution/{executionId}/phase/{phaseId}/step/{stepId}/artifacts':
     get:
       tags:
         - Execution Artifacts
@@ -1027,16 +927,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -1048,7 +944,7 @@ paths:
           description: Missing permission for user to read artifacts
         '404':
           description: Pipeline execution does not exist
-  /api/program/{programId}/pipeline/{pipelineId}/execution/{executionId}/phase/{phaseId}/step/{stepId}/artifact/{artifactId}:
+  '/api/program/{programId}/pipeline/{pipelineId}/execution/{executionId}/phase/{phaseId}/step/{stepId}/artifact/{artifactId}':
     get:
       tags:
         - Execution Artifacts
@@ -1097,16 +993,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -1116,7 +1008,7 @@ paths:
           description: Missing permission for user to read artifact
         '404':
           description: Pipeline execution does not exist
-  /api/program/{programId}/pipeline/{pipelineId}/execution/{executionId}/phase/{phaseId}/step/{stepId}/metrics:
+  '/api/program/{programId}/pipeline/{pipelineId}/execution/{executionId}/phase/{phaseId}/step/{stepId}/metrics':
     get:
       tags:
         - Pipeline Execution
@@ -1156,16 +1048,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -1177,7 +1065,7 @@ paths:
           description: Missing permission for user to read metrics
         '404':
           description: Pipeline execution does not exist
-  /api/program/{programId}/pipeline/{pipelineId}/executions:
+  '/api/program/{programId}/pipeline/{pipelineId}/executions':
     get:
       tags:
         - Pipeline Execution
@@ -1213,16 +1101,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -1234,7 +1118,7 @@ paths:
           description: Missing permission for user to read executions
         '404':
           description: Pipeline does not exist
-  /api/program/{programId}/environments:
+  '/api/program/{programId}/environments':
     get:
       tags:
         - Environments
@@ -1258,7 +1142,6 @@ paths:
             - prod
             - rde
             - preprod
-            - devxl
         - name: x-gw-ims-org-id
           in: header
           description: IMS organization ID that the request is being made under.
@@ -1266,16 +1149,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -1310,16 +1189,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -1334,7 +1209,7 @@ paths:
             $ref: '#/definitions/Environment'
         '400':
           description: Bad request
-  /api/program/{programId}/environment/{environmentId}:
+  '/api/program/{programId}/environment/{environmentId}':
     get:
       tags:
         - Environments
@@ -1359,16 +1234,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -1395,9 +1266,7 @@ paths:
           type: string
         - name: ignoreResourcesDeletionResult
           in: query
-          description: >-
-            Ignore Resources Deletion Result option, delete flow does not fail
-            if resources could not be deleted
+          description: 'Ignore Resources Deletion Result option, delete flow does not fail if resources could not be deleted'
           required: false
           type: boolean
           default: false
@@ -1408,16 +1277,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -1431,7 +1296,7 @@ paths:
             $ref: '#/definitions/BadRequestError'
         '404':
           description: Environment not found
-  /api/program/{programId}/environment/{environmentId}/regionDeployments/{regionDeploymentId}:
+  '/api/program/{programId}/environment/{environmentId}/regionDeployments/{regionDeploymentId}':
     get:
       tags:
         - Region Deployments
@@ -1461,16 +1326,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -1478,7 +1339,7 @@ paths:
           description: Successful retrieval of the region deployment for the environment
           schema:
             $ref: '#/definitions/RegionDeployment'
-  /api/program/{programId}/environment/{environmentId}/regionDeployments:
+  '/api/program/{programId}/environment/{environmentId}/regionDeployments':
     get:
       tags:
         - Region Deployments
@@ -1503,16 +1364,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -1552,16 +1409,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -1608,16 +1461,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -1636,7 +1485,7 @@ paths:
             $ref: '#/definitions/BadRequestError'
         '404':
           description: Region deployment not found for the given identifier
-  /api/program/{programId}/environment/{environmentId}/logs:
+  '/api/program/{programId}/environment/{environmentId}/logs':
     get:
       tags:
         - Environments
@@ -1683,16 +1532,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -1706,7 +1551,7 @@ paths:
             $ref: '#/definitions/BadRequestError'
         '404':
           description: Environment not found
-  /api/program/{programId}/environment/{environmentId}/logs/download:
+  '/api/program/{programId}/environment/{environmentId}/logs/download':
     get:
       tags:
         - Environments
@@ -1747,25 +1592,18 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
         - name: Accept
           required: false
           type: string
-          description: >-
-            Specify application/json in this header to receive a JSON response.
-            Otherwise, a 307 response code will be returned with a Location
-            header.
+          description: 'Specify application/json in this header to receive a JSON response. Otherwise, a 307 response code will be returned with a Location header.'
           in: header
       responses:
         '200':
@@ -1778,7 +1616,7 @@ paths:
             $ref: '#/definitions/BadRequestError'
         '404':
           description: Environment not found
-  /api/program/{programId}/environment/{environmentId}/variables:
+  '/api/program/{programId}/environment/{environmentId}/variables':
     get:
       tags:
         - Variables
@@ -1805,16 +1643,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -1828,9 +1662,7 @@ paths:
       tags:
         - Variables
       summary: Patch User Environment Variables
-      description: >-
-        Modify multiple environment variables (Cloud Service only). To delete a
-        variable, include it with an empty value.
+      description: 'Modify multiple environment variables (Cloud Service only). To delete a variable, include it with an empty value.'
       operationId: patchEnvironmentVariables
       parameters:
         - name: programId
@@ -1845,10 +1677,7 @@ paths:
           type: string
         - in: body
           name: body
-          description: >-
-            The list of variables to add, modify, or remove. It is not necessary
-            to send variables here which are not changing. The length of
-            `secretString` values must be less than 500 characters.
+          description: 'The list of variables to add, modify, or remove. It is not necessary to send variables here which are not changing. The length of `secretString` values must be less than 500 characters.'
           required: true
           schema:
             type: array
@@ -1861,16 +1690,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -1883,14 +1708,12 @@ paths:
           description: Successful setting of variables
         '404':
           description: Environment not found
-  /api/program/{programId}/environment/{environmentId}/reset:
+  '/api/program/{programId}/environment/{environmentId}/reset':
     put:
       tags:
         - Rapid Development Environments
       summary: Reset Rapid Development Environment
-      description: >-
-        Reset Rapid Development Environment. Also updates the RDE to the latest
-        AEM release.
+      description: Reset Rapid Development Environment. Also updates the RDE to the latest AEM release.
       operationId: resetRde
       parameters:
         - name: programId
@@ -1910,16 +1733,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -1927,7 +1746,7 @@ paths:
           description: Successfully reset RDE
         '404':
           description: Environment not found
-  /api/program/{programId}/environment/{environmentId}/restorePoints:
+  '/api/program/{programId}/environment/{environmentId}/restorePoints':
     get:
       tags:
         - Environment Restore From Backup
@@ -1952,16 +1771,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -1971,7 +1786,7 @@ paths:
             $ref: '#/definitions/RestorePointsList'
         '404':
           description: Resource not found
-  /api/program/{programId}/environment/{environmentId}/restoreExecution/{restoreId}:
+  '/api/program/{programId}/environment/{environmentId}/restoreExecution/{restoreId}':
     get:
       tags:
         - Environment Restore From Backup
@@ -2001,16 +1816,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -2018,7 +1829,7 @@ paths:
           description: successful operation
           schema:
             $ref: '#/definitions/RestoreExecution'
-  /api/program/{programId}/environment/{environmentId}/restoreExecution/{restoreId}/logs:
+  '/api/program/{programId}/environment/{environmentId}/restoreExecution/{restoreId}/logs':
     get:
       tags:
         - Environment Restore From Backup
@@ -2052,22 +1863,18 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
         default:
           description: successful operation
-  /api/program/{programId}/environment/{environmentId}/restoreExecutions:
+  '/api/program/{programId}/environment/{environmentId}/restoreExecutions':
     get:
       tags:
         - Environment Restore From Backup
@@ -2105,16 +1912,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -2122,7 +1925,7 @@ paths:
           description: successful operation
           schema:
             $ref: '#/definitions/RestoreExecutionList'
-  /api/program/{programId}/environment/{environmentId}/restoreExecution:
+  '/api/program/{programId}/environment/{environmentId}/restoreExecution':
     put:
       tags:
         - Environment Restore From Backup
@@ -2153,16 +1956,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -2179,7 +1978,7 @@ paths:
           description: Environment not found
         '412':
           description: Restore precondition failed
-  /api/program/{programId}/pipeline/{pipelineId}/variables:
+  '/api/program/{programId}/pipeline/{pipelineId}/variables':
     get:
       tags:
         - Variables
@@ -2206,16 +2005,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -2229,9 +2024,7 @@ paths:
       tags:
         - Variables
       summary: Patch User Pipeline Variables
-      description: >-
-        Modify multiple pipeline variables. To delete a variable, include it
-        with an empty value.
+      description: 'Modify multiple pipeline variables. To delete a variable, include it with an empty value.'
       operationId: patchPipelineVariables
       parameters:
         - name: programId
@@ -2246,10 +2039,7 @@ paths:
           type: string
         - in: body
           name: body
-          description: >-
-            The list of variables to add, modify, or remove. It is not necessary
-            to send variables here which are not changing. The length of
-            `secretString` values must be less than 500 characters.
+          description: 'The list of variables to add, modify, or remove. It is not necessary to send variables here which are not changing. The length of `secretString` values must be less than 500 characters.'
           required: true
           schema:
             type: array
@@ -2262,16 +2052,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -2284,7 +2070,7 @@ paths:
           description: Successful setting of variables
         '404':
           description: Pipeline not found
-  /api/program/{programId}/ipAllowlist/{ipAllowlistId}:
+  '/api/program/{programId}/ipAllowlist/{ipAllowlistId}':
     get:
       tags:
         - IP Allowlist
@@ -2309,16 +2095,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -2350,7 +2132,7 @@ paths:
           description: IP Allowlist
           required: true
           schema:
-            $ref: '#/definitions/IPAllowedList'
+            $ref: '#/definitions/Updateanipallowlist'
         - name: x-gw-ims-org-id
           in: header
           description: IMS organization ID that the request is being made under.
@@ -2358,16 +2140,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -2408,16 +2186,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -2427,7 +2201,7 @@ paths:
             $ref: '#/definitions/IPAllowedList'
         '404':
           description: Resource not found
-  /api/program/{programId}/ipAllowlist/{ipAllowlistId}/binding/{ipAllowlistBindingId}:
+  '/api/program/{programId}/ipAllowlist/{ipAllowlistId}/binding/{ipAllowlistBindingId}':
     get:
       tags:
         - IP Allowlist Binding
@@ -2457,16 +2231,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -2505,16 +2275,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -2524,58 +2290,7 @@ paths:
             $ref: '#/definitions/IPAllowedListBinding'
         '404':
           description: IP Allowlist not found
-  /api/program/{programId}/ipAllowlist/{ipAllowlistId}/binding/{ipAllowlistBindingId}/retry:
-    put:
-      tags:
-        - IP Allowlist Binding
-      summary: Retry IP Allowlist binding action
-      description: >-
-        Retry the IP Allowlist binding action for the program and IP Allowlist
-        id
-      operationId: retryIPAllowlistBinding
-      parameters:
-        - name: programId
-          in: path
-          description: Identifier of the program
-          required: true
-          type: string
-        - name: ipAllowlistId
-          in: path
-          description: Identifier of the IP Allowlist
-          required: true
-          type: string
-        - name: ipAllowlistBindingId
-          in: path
-          description: Identifier of the IP Allowlist binding
-          required: true
-          type: string
-        - name: x-gw-ims-org-id
-          in: header
-          description: IMS organization ID that the request is being made under.
-          required: true
-          type: string
-        - name: Authorization
-          in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
-          required: true
-          type: string
-        - name: x-api-key
-          in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
-          required: true
-          type: string
-      responses:
-        '202':
-          description: Retry operation was successful
-          schema:
-            $ref: '#/definitions/IPAllowedListBinding'
-        '404':
-          description: IP Allowlist not found
-  /api/program/{programId}/ipAllowlist/{ipAllowlistId}/bindings:
+  '/api/program/{programId}/ipAllowlist/{ipAllowlistId}/bindings':
     get:
       tags:
         - IP Allowlist Binding
@@ -2600,16 +2315,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -2649,16 +2360,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -2681,7 +2388,7 @@ paths:
           description: Environment not found
         '412':
           description: Creating IP Allowlists for non cloud programs is not supported
-  /api/program/{programId}/ipAllowlists:
+  '/api/program/{programId}/ipAllowlists':
     get:
       tags:
         - IP Allowlist
@@ -2701,16 +2408,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -2737,7 +2440,7 @@ paths:
           description: IP Allowlist
           required: true
           schema:
-            $ref: '#/definitions/IPAllowedList'
+            $ref: '#/definitions/Createanewipallowlist'
         - name: x-gw-ims-org-id
           in: header
           description: IMS organization ID that the request is being made under.
@@ -2745,16 +2448,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -2777,32 +2476,39 @@ paths:
           description: Program not found
         '412':
           description: Creating IP Allowlists for non cloud programs is not supported
-  /api/program/{programId}/domainNames:
+  '/api/program/{programId}/domains':
     get:
       tags:
-        - Domain Names
-      summary: List Domain Names
-      description: Lists all domain names in an program
-      operationId: getDomainNames
+        - Domain
+      summary: Get list of domains
+      description: ''
+      operationId: getDomain
       parameters:
         - name: programId
           in: path
-          description: Identifier of the program
+          description: Identifier of program id
           required: true
           type: string
-        - name: start
+        - name: name
           in: query
-          description: Pagination start parameter
+          description: Domain name
           required: false
           type: string
-          default: '0'
-        - name: limit
+        - name: anyVerified
           in: query
-          description: Pagination limit parameter
+          description: Filter any verified
           required: false
-          type: integer
-          default: 20
-          format: int32
+          type: boolean
+        - name: isTxt
+          in: query
+          description: Is TXT verified
+          required: false
+          type: boolean
+        - name: isAcme
+          in: query
+          description: Is ACME verified
+          required: false
+          type: boolean
         - name: x-gw-ims-org-id
           in: header
           description: IMS organization ID that the request is being made under.
@@ -2810,41 +2516,37 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
         '200':
-          description: successful operation
+          description: List of domains received
           schema:
-            $ref: '#/definitions/DomainNameList'
+            $ref: '#/definitions/Domain'
     post:
       tags:
-        - Domain Names
-      summary: Create a Domain name
-      description: Create a new Domain name for an Environment
-      operationId: createEnvironmentDomainName
+        - Domain
+      summary: Create a domain
+      description: ''
+      operationId: createDomain
       parameters:
         - name: programId
           in: path
-          description: Identifier of the program
+          description: Identifier of program
           required: true
           type: string
         - in: body
           name: body
-          description: Domain Name
+          description: Payload for creating a domain
           required: true
           schema:
-            $ref: '#/definitions/NewDomainName'
+            $ref: '#/definitions/DomainCreate'
         - name: x-gw-ims-org-id
           in: header
           description: IMS organization ID that the request is being made under.
@@ -2852,16 +2554,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -2870,28 +2568,30 @@ paths:
           required: true
           type: string
       responses:
-        '201':
-          description: Domain name created
+        '200':
+          description: Domain created
           schema:
-            $ref: '#/definitions/DomainName'
+            $ref: '#/definitions/Domain'
         '404':
-          description: Resource not found
-  /api/program/{programId}/domainName/{domainNameId}:
+          description: Program not found
+        '409':
+          description: Domain already exists
+  '/api/program/{programId}/domain/{domain-id}':
     get:
       tags:
-        - Domain Names
-      summary: Get Domain Name
-      description: Returns a domain name by its id
-      operationId: getEnvironmentDomainName
+        - Domain
+      summary: Get domain
+      description: ''
+      operationId: getDomain
       parameters:
         - name: programId
           in: path
-          description: Identifier of the program
+          description: Identifier of program id
           required: true
           type: string
-        - name: domainNameId
+        - name: domain-id
           in: path
-          description: Domain Name id
+          description: Identifier of domain id
           required: true
           type: string
         - name: x-gw-ims-org-id
@@ -2901,46 +2601,44 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
         '200':
-          description: successful operation
+          description: Domain received
           schema:
-            $ref: '#/definitions/DomainName'
-    put:
+            $ref: '#/definitions/Domain'
+        '404':
+          description: Domain not found
+      put:
       tags:
-        - Domain Names
-      summary: Update Domain Name
-      description: Updates a domain name by its id.
-      operationId: updateEnvironmentDomainName
+        - Domain
+      summary: Update domain
+      description: ''
+      operationId: modifyDomain
       parameters:
         - name: programId
           in: path
-          description: Identifier of the program
+          description: Identifier of program id
           required: true
           type: string
-        - name: domainNameId
+        - name: domain-id
           in: path
-          description: Identifier of the domain name
+          description: Identifier of domain id
           required: true
           type: string
         - in: body
           name: body
-          description: Updated domain name
+          description: Domain Update Body
           required: true
           schema:
-            $ref: '#/definitions/DomainName'
+            $ref: '#/definitions/UpdateaDomain''snameorlabel'
         - name: x-gw-ims-org-id
           in: header
           description: IMS organization ID that the request is being made under.
@@ -2948,16 +2646,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -2967,30 +2661,26 @@ paths:
           type: string
       responses:
         '200':
-          description: successful operation
+          description: Domain updated
           schema:
-            $ref: '#/definitions/DomainName'
-        '202':
-          description: Updating domain name
-          schema:
-            $ref: '#/definitions/DomainName'
+            $ref: '#/definitions/Domain'
         '404':
-          description: Resource not found
+          description: Program not found
     delete:
       tags:
-        - Domain Names
-      summary: Delete Domain Name
-      description: Deletes a domain name by its id
-      operationId: deleteEnvironmentDomainName
+        - Domain
+      summary: Delete a domain
+      description: ''
+      operationId: deleteDomain
       parameters:
         - name: programId
           in: path
-          description: Identifier of the program
+          description: Identifier of program id
           required: true
           type: string
-        - name: domainNameId
+        - name: domain-id
           in: path
-          description: Identifier of the Domain Name
+          description: Identifier of domain id
           required: true
           type: string
         - name: x-gw-ims-org-id
@@ -3000,136 +2690,43 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
-          required: true
-          type: string
-      responses:
-        '202':
-          description: Deleting domain Name
-          schema:
-            $ref: '#/definitions/DomainName'
-        '404':
-          description: Resource not found
-  /api/program/{programId}/domainName/{domainNameId}/deploy:
-    post:
-      tags:
-        - Domain Names
-      summary: Verify and deploy a Domain name
-      description: Verify and deploy a Domain name
-      operationId: deployDomainName
-      parameters:
-        - name: programId
-          in: path
-          description: Identifier of the program
-          required: true
-          type: string
-        - name: domainNameId
-          in: path
-          description: Domain Name id
-          required: true
-          type: string
-        - name: x-gw-ims-org-id
-          in: header
-          description: IMS organization ID that the request is being made under.
-          required: true
-          type: string
-        - name: Authorization
-          in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
-          required: true
-          type: string
-        - name: x-api-key
-          in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
         '200':
-          description: Domain name verified
+          description: Domain deleted
           schema:
-            $ref: '#/definitions/DomainName'
-        '404':
-          description: Resource not found
-  /api/program/{programId}/domainName/{domainNameId}/verify:
-    post:
+            $ref: '#/definitions/Response'
+            '/api/program/{programId}/domain/{domain-id}/validate':
+    put:
       tags:
-        - Domain Names
-      summary: Makes a DNS resolution
-      description: Make a DNS resolution
-      operationId: verifyDomainName
+        - Domain
+      summary: Check validation
+      description: ''
+      operationId: domainValidationToken
       parameters:
         - name: programId
           in: path
-          description: Identifier of the program
+          description: Identifier of program id
           required: true
           type: string
-        - name: domainNameId
+        - name: domain-id
           in: path
-          description: Identifier of the domain name
-          required: true
-          type: string
-        - name: x-gw-ims-org-id
-          in: header
-          description: IMS organization ID that the request is being made under.
-          required: true
-          type: string
-        - name: Authorization
-          in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
-          required: true
-          type: string
-        - name: x-api-key
-          in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
-          required: true
-          type: string
-      responses:
-        '200':
-          description: successful operation
-          schema:
-            $ref: '#/definitions/DomainName'
-        '202':
-          description: Domain name is being verified
-          schema:
-            $ref: '#/definitions/DomainName'
-        '404':
-          description: Resource not found
-  /api/program/{programId}/domainNames/validate:
-    post:
-      tags:
-        - Domain Names
-      summary: Validate an Domain name
-      description: Validate a new Domain name
-      operationId: validateDomainName
-      parameters:
-        - name: programId
-          in: path
-          description: Identifier of the program
+          description: Identifier of domain id
           required: true
           type: string
         - in: body
           name: body
-          description: Domain name to be validated
+          description: Payload for validation operation
           required: true
           schema:
-            $ref: '#/definitions/DomainNameValidate'
+            $ref: '#/definitions/DomainTokenValidationBody'
         - name: x-gw-ims-org-id
           in: header
           description: IMS organization ID that the request is being made under.
@@ -3137,16 +2734,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -3156,29 +2749,421 @@ paths:
           type: string
       responses:
         '200':
-          description: Domain name successfully validated
+          description: Validation is completed
           schema:
-            $ref: '#/definitions/DomainName'
+            $ref: '#/definitions/Domain'
         '404':
-          description: Resource not found
-  /api/program/{programId}/certificate/{certificateId}:
+          description: Program not found
+  '/api/program/{programId}/domain/{domain-id}/validation':
+    post:
+      tags:
+        - Domain
+      summary: Creates validation token
+      description: ''
+      operationId: domainValidationToken
+      parameters:
+        - name: programId
+          in: path
+          description: Identifier of program id
+          required: true
+          type: string
+        - name: domain-id
+          in: path
+          description: Identifier of domain id
+          required: true
+          type: string
+        - in: body
+          name: body
+          description: Payload for validation operation
+          required: true
+          schema:
+            $ref: '#/definitions/DomainTokenValidationBody'
+        - name: x-gw-ims-org-id
+          in: header
+          description: IMS organization ID that the request is being made under.
+          required: true
+          type: string
+        - name: Authorization
+          in: header
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          required: true
+          type: string
+        - name: x-api-key
+          in: header
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          required: true
+          type: string
+        - name: Content-Type
+          in: header
+          description: Must always be application/json
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Created validation token
+          schema:
+            $ref: '#/definitions/Domain'
+        '404':
+          description: Program Not found
+  '/api/program/{programId}/domain-mapping/{domainMappingId}':
     get:
       tags:
-        - SSLCertificates
-      summary: Get SSL Certificate
-      description: Returns an SSL Certificate by its id
-      operationId: getCertificate
+        - Domain Mappings - CDN Configurations
+      summary: Get domain mapping
+      description: ''
+      operationId: getDomainMappingById
+      parameters:
+        - name: programId
+          in: path
+          description: Identifier of program
+          required: true
+          type: integer
+          format: int64
+        - name: domainMappingId
+          in: path
+          description: Identifier of domain mapping
+          required: true
+          type: integer
+          format: int64
+        - name: x-gw-ims-org-id
+          in: header
+          description: IMS organization ID that the request is being made under.
+          required: true
+          type: string
+        - name: Authorization
+            in: header
+            description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+            required: true
+            type: string
+        - name: x-api-key
+          in: header
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Domain Mapping retrieved
+          schema:
+            $ref: '#/definitions/DomainMapping'
+        '404':
+          description: Domain Mapping not found
+    put:
+      tags:
+        - Domain Mappings - CDN Configurations
+      summary: Update domain mapping
+      description: ''
+      operationId: updateDomainMapping
+      parameters:
+        - name: programId
+          in: path
+            description: Identifier of program
+          required: true
+          type: integer
+          format: int64
+        - name: domainMappingId
+          in: path
+          description: Identifier of domain mapping
+          required: true
+          type: integer
+          format: int64
+        - in: body
+          name: body
+          description: Payload for updating a domain mapping
+          required: true
+          schema:
+            $ref: '#/definitions/Updateadomainmapping'
+        - name: x-gw-ims-org-id
+          in: header
+          description: IMS organization ID that the request is being made under.
+          required: true
+          type: string
+        - name: Authorization
+          in: header
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          required: true
+          type: string
+        - name: x-api-key
+          in: header
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          required: true
+          type: string
+        - name: Content-Type
+          in: header
+          description: Must always be application/json
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Domain Mapping updated
+          schema:
+            $ref: '#/definitions/DomainMapping'
+        '404':
+          description: Domain Mapping not found
+    delete:
+      tags:
+        - Domain Mappings - CDN Configurations
+      summary: Delete domain mapping
+      description: ''
+      operationId: deleteDomainMapping
+      parameters:
+        - name: programId
+          in: path
+          description: Identifier of program
+          required: true
+          type: integer
+          format: int64
+        - name: domainMappingId
+          in: path
+          description: Identifier of domain mapping
+          required: true
+          type: integer
+          format: int64
+        - name: x-gw-ims-org-id
+          in: header
+          description: IMS organization ID that the request is being made under.
+          required: true
+          type: string
+        - name: Authorization
+          in: header
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          required: true
+          type: string
+        - name: x-api-key
+          in: header
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Domain Mapping deleted
+          schema:
+            $ref: '#/definitions/DomainMapping'
+        '404':
+          description: Domain Mapping not found
+  '/api/program/{programId}/domain-mapping/{domainMappingId}/verify':
+    put:
+      tags:
+        - Domain Mappings - CDN Configurations
+      summary: Check if customer made the required DNS changes
+      description: ''
+      operationId: validateHelixDomain
+      parameters:
+        - name: programId
+          in: path
+          description: Identifier of program
+          required: true
+          type: integer
+          format: int64
+        - name: domainMappingId
+          in: path
+          description: Identifier of domain mapping
+          required: true
+          type: integer
+          format: int64
+        - name: x-gw-ims-org-id
+          in: header
+          description: IMS organization ID that the request is being made under.
+          required: true
+          type: string
+        - name: Authorization
+          in: header
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          required: true
+          type: string
+        - name: x-api-key
+          in: header
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          required: true
+          type: string
+      responses:
+        '200':
+          description: DNS changes were successfully made
+          schema:
+            $ref: '#/definitions/DomainMapping'
+        '404':
+          description: Program not found
+  '/api/program/{programId}/domain-mappings':
+    get:
+      tags:
+        - Domain Mappings - CDN Configurations
+      summary: List of domain mappings
+      description: ''
+      operationId: getAllDomainMappingsByProgramId
+      parameters:
+        - name: programId
+          in: path
+          description: Identifier of program
+          required: true
+          type: integer
+          format: int64
+        - name: x-gw-ims-org-id
+          in: header
+          description: IMS organization ID that the request is being made under.
+          required: true
+          type: string
+        - name: Authorization
+          in: header
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          required: true
+          type: string
+        - name: x-api-key
+          in: header
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          required: true
+          type: string
+      responses:
+        '200':
+          description: List of domain mappings retrieved
+          schema:
+            $ref: '#/definitions/DomainMappingList'
+      post:
+        tags:
+          - Domain Mappings - CDN Configurations
+        summary: Create domain mapping
+        description: ''
+        operationId: createDomainMapping
+        parameters:
+          - name: programId
+            in: path
+            description: Identifier of program
+            required: true
+            type: integer
+            format: int64
+          - in: body
+            name: body
+            description: Payload for creating a domain mapping
+            required: true
+            schema:
+              $ref: '#/definitions/Createanewdomainmapping'
+          - name: x-gw-ims-org-id
+            in: header
+            description: IMS organization ID that the request is being made under.
+            required: true
+            type: string
+          - name: Authorization
+            in: header
+            description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+            required: true
+            type: string
+          - name: x-api-key
+            in: header
+            description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+            required: true
+            type: string
+          - name: Content-Type
+            in: header
+            description: Must always be application/json
+            required: true
+            type: string
+        responses:
+          '200':
+            description: successful operation
+            schema:
+              $ref: '#/definitions/DomainMapping'
+          '201':
+            description: Domain Mapping created
+            schema:
+              $ref: '#/definitions/DomainMapping'
+  '/api/program/{programId}/environment/{environmentId}/domain-mappings':
+    get:
+      tags:
+        - Domain Mappings - CDN Configurations
+      summary: List of domain mappings by environment
+      description: ''
+      operationId: getAllDomainMappingsByProgramIdAndEnvironmentId
+      parameters:
+        - name: programId
+          in: path
+          description: Identifier of program
+          required: true
+          type: integer
+          format: int64
+        - name: environmentId
+          in: path
+          description: Identifier of environment
+          required: true
+          type: integer
+          format: int64
+        - name: x-gw-ims-org-id
+          in: header
+          description: IMS organization ID that the request is being made under.
+          required: true
+          type: string
+        - name: Authorization
+          in: header
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          required: true
+          type: string
+        - name: x-api-key
+          in: header
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          required: true
+          type: string
+      responses:
+        '200':
+          description: List of domain mappings by environment retrieved
+          schema:
+            $ref: '#/definitions/DomainMappingList'
+  '/api/program/{programId}/site/{siteId}/domain-mappings':
+    get:
+      tags:
+        - Domain Mappings - CDN Configurations
+      summary: List of domain mappings by EDS site
+      description: ''
+      operationId: getAllDomainMappingsByProgramIdAndSiteId
+      parameters:
+        - name: programId
+          in: path
+          description: Identifier of program
+          required: true
+          type: integer
+          format: int64
+        - name: siteId
+          in: path
+          description: Identifier of EDS site
+          required: true
+          type: integer
+          format: int64
+        - name: x-gw-ims-org-id
+          in: header
+          description: IMS organization ID that the request is being made under.
+          required: true
+          type: string
+        - name: Authorization
+          in: header
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          required: true
+          type: string
+        - name: x-api-key
+          in: header
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          required: true
+          type: string
+      responses:
+        '200':
+          description: List of domain mappings by environment retrieved
+          schema:
+            $ref: '#/definitions/DomainMappingList'
+  '/api/program/{programId}/certificate/{certificateId}':
+    get:
+      tags:
+        - SSL Certificates
+      summary: Get certificate by ID
+      description: ''
+      operationId: getCertificateByIdAndProgramId
       parameters:
         - name: programId
           in: path
           description: Identifier of the program
           required: true
-          type: string
+          type: integer
+          format: int64
         - name: certificateId
           in: path
           description: Identifier of the certificate
           required: true
-          type: string
+          type: integer
+          format: int64
         - name: x-gw-ims-org-id
           in: header
           description: IMS organization ID that the request is being made under.
@@ -3186,50 +3171,48 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
         '200':
-          description: successful operation
+          description: Certificate retrieved
           schema:
-            $ref: '#/definitions/SslCertificate'
+            $ref: '#/definitions/SslCertificateRepresentation'
         '404':
           description: Certificate not found
           schema:
             $ref: '#/definitions/SslCertificateNotFoundException'
     put:
       tags:
-        - SSLCertificates
-      summary: Update SSL Certificate
-      description: Update a certificate.
+        - SSL Certificates
+      summary: Update certificate
+      description: ''
       operationId: updateCertificate
       parameters:
         - name: programId
           in: path
           description: Identifier of the program
           required: true
-          type: string
+          type: integer
+          format: int64
         - name: certificateId
           in: path
           description: Identifier of the certificate
           required: true
-          type: string
+          type: integer
+          format: int64
         - in: body
           name: body
-          description: Updated certificate
+          description: Payload for updating the certificate
           required: true
           schema:
-            $ref: '#/definitions/SslCertificate'
+            $ref: '#/definitions/CreateOrUpdateSslCertificateBody'
         - name: x-gw-ims-org-id
           in: header
           description: IMS organization ID that the request is being made under.
@@ -3237,16 +3220,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -3258,28 +3237,30 @@ paths:
         '200':
           description: Certificate updated
           schema:
-            $ref: '#/definitions/SslCertificate'
+            $ref: '#/definitions/SslCertificateRepresentation'
         '404':
-          description: Resource not found
+          description: Certificate not found
           schema:
             $ref: '#/definitions/SslCertificateNotFoundException'
     delete:
       tags:
-        - SSLCertificates
-      summary: Delete SSL Certificate
-      description: Delete an SSL Certificate.
+        - SSL Certificates
+      summary: Delete a certificate
+      description: ''
       operationId: deleteCertificate
       parameters:
         - name: programId
           in: path
           description: Identifier of the program
           required: true
-          type: string
+          type: integer
+          format: int64
         - name: certificateId
           in: path
           description: Identifier of the certificate
           required: true
-          type: string
+          type: integer
+          format: int64
         - name: x-gw-ims-org-id
           in: header
           description: IMS organization ID that the request is being made under.
@@ -3287,16 +3268,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -3304,32 +3281,24 @@ paths:
           description: Certificate deleted
           schema:
             $ref: '#/definitions/SslCertificateRepresentation'
-        '204':
-          description: Certificate deleted
-          schema:
-            $ref: '#/definitions/SslCertificate'
         '404':
-          description: Resource not found
+          description: Certificate not found
           schema:
             $ref: '#/definitions/SslCertificateNotFoundException'
-  /api/program/{programId}/certificates:
+  '/api/program/{programId}/certificates':
     get:
       tags:
-        - SSLCertificates
-      summary: List certificates
-      description: Lists all certificates in a program
-      operationId: getCertificates
+        - SSL Certificates
+      summary: Get all certificates
+      description: ''
+      operationId: getAllCertificatesForProgram
       parameters:
         - name: programId
           in: path
           description: Identifier of the program
           required: true
-          type: string
-        - name: domain
-          in: query
-          description: Domain name used for filtering the certificates
-          required: false
-          type: string
+          type: integer
+          format: int64
         - name: start
           in: query
           description: Pagination start parameter
@@ -3343,6 +3312,29 @@ paths:
           type: integer
           default: 20
           format: int32
+        - name: status
+          in: query
+          description: Filter statuses separated by comma
+          required: false
+          type: string
+          enum:
+            - VALID
+            - PENDING
+            - EXPIRED
+        - name: name
+          in: query
+          description: Certificate name
+          required: false
+          type: string
+        - name: sslCertificateType
+          in: query
+          description: Certificate types separated by comma.
+          required: false
+          type: string
+          enum:
+            - DV
+            - EV
+            - OV
         - name: x-gw-ims-org-id
           in: header
           description: IMS organization ID that the request is being made under.
@@ -3350,57 +3342,38 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
-          required: true
-          type: string
-        - name: Authorization
-          in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
-          required: true
-          type: string
-        - name: x-api-key
-          in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
         '200':
-          description: Successful retrieval of certificates list
+          description: Certificate list retrieved
           schema:
-            $ref: '#/definitions/CertificatesList'
-        '404':
-          description: Program not found
+            $ref: '#/definitions/AllSSLCertificatesList'
     post:
       tags:
-        - SSLCertificates
-      summary: Create SSL Certificate
-      description: Create a new certificate.
-      operationId: createCertificate
+        - SSL Certificates
+      summary: Create SSL certificate
+      description: ''
+      operationId: createSslCertificate
       parameters:
         - name: programId
           in: path
           description: Identifier of the program
           required: true
-          type: string
+          type: integer
+          format: int64
         - in: body
           name: body
-          description: Certificate
+          description: Payload for creating the certificate
           required: true
           schema:
-            $ref: '#/definitions/NewSslCertificate'
+            $ref: '#/definitions/CreateOrUpdateSslCertificateBody'
         - name: x-gw-ims-org-id
           in: header
           description: IMS organization ID that the request is being made under.
@@ -3408,16 +3381,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -3431,12 +3400,282 @@ paths:
           schema:
             $ref: '#/definitions/SslCertificateRepresentation'
         '201':
-          description: Certificate created
+          description: SSL certificate created
+          schema:
+            $ref: '#/definitions/SslCertificateRepresentation'
+  '/api/program/{programId}/dv-certificates':
+    post:
+      tags:
+        - SSL Certificates
+      summary: Create DV certificate
+      description: ''
+      operationId: createDvCertificate
+      parameters:
+        - name: programId
+          in: path
+          description: Identifier of the program
+          required: true
+          type: integer
+          format: int64
+        - in: body
+          name: body
+          description: Payload for creating the DV certificate
+          required: true
+          schema:
+            $ref: '#/definitions/CreateDvCertificateBody'
+        - name: x-gw-ims-org-id
+          in: header
+          description: IMS organization ID that the request is being made under.
+          required: true
+          type: string
+        - name: Authorization
+          in: header
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          required: true
+          type: string
+        - name: x-api-key
+          in: header
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          required: true
+          type: string
+        - name: Content-Type
+          in: header
+          description: Must always be application/json
+          required: true
+          type: string
+      responses:
+        '200':
+          description: successful operation
           schema:
             $ref: '#/definitions/SslCertificate'
+        '201':
+          description: Created DV certificate
+          schema:
+            $ref: '#/definitions/SslCertificate'
+  '/api/program/{programId}/site/{siteId}':
+    get:
+      tags:
+        - EDS Sites
+      summary: Get Site by Id
+      description: ''
+      operationId: retrieveSite
+      parameters:
+        - name: programId
+          in: path
+          required: true
+          type: string
+        - name: siteId
+          in: path
+          required: true
+          type: integer
+          format: int64
+        - name: x-gw-ims-org-id
+          in: header
+          description: IMS organization ID that the request is being made under.
+          required: true
+          type: string
+        - name: Authorization
+          in: header
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          required: true
+          type: string
+        - name: x-api-key
+          in: header
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Site retrieved
+          schema:
+            $ref: '#/definitions/Site'
         '404':
-          description: Program not found
-  /api/program/{programId}/feedbacks:
+          description: Site could not be found
+    put:
+      tags:
+        - EDS Sites
+      summary: Update Site
+      description: ''
+      operationId: updateSite
+      parameters:
+        - name: programId
+          in: path
+          required: true
+          type: string
+        - name: siteId
+          in: path
+          required: true
+          type: integer
+          format: int64
+        - name: x-gw-ims-org-id
+          in: header
+          description: IMS organization ID that the request is being made under.
+          required: true
+          type: string
+        - name: Authorization
+          in: header
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          required: true
+          type: string
+        - name: x-api-key
+          in: header
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Site updated
+          schema:
+            $ref: '#/definitions/Site'
+        '404':
+          description: Site could not be found
+    delete:
+      tags:
+        - EDS Sites
+      summary: Delete Site
+      description: ''
+      operationId: deleteSite
+      parameters:
+        - name: programId
+          in: path
+          required: true
+          type: string
+        - name: siteId
+          in: path
+          required: true
+          type: integer
+          format: int64
+        - name: x-gw-ims-org-id
+          in: header
+          description: IMS organization ID that the request is being made under.
+          required: true
+          type: string
+        - name: Authorization
+          in: header
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          required: true
+          type: string
+        - name: x-api-key
+          in: header
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Site deleted
+          schema:
+            $ref: '#/definitions/Site'
+        '404':
+          description: Site could not be found
+  '/api/program/{programId}/site/{siteId}/validate':
+    put:
+      tags:
+        - EDS Sites
+      summary: Validate Site
+      description: ''
+      operationId: validateSite
+      parameters:
+        - name: programId
+          in: path
+          description: Identifier of the program
+          required: true
+          type: string
+        - name: siteId
+          in: path
+          description: Identifier of the site
+          required: true
+          type: integer
+          format: int64
+        - name: x-gw-ims-org-id
+          in: header
+          description: IMS organization ID that the request is being made under.
+          required: true
+          type: string
+        - name: Authorization
+          in: header
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          required: true
+          type: string
+        - name: x-api-key
+          in: header
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Site validated
+          schema:
+            $ref: '#/definitions/Site'
+        '400':
+          description: Site could not be validated. CloudManager challenge does not match
+        '500':
+          description: Internal Server Error
+        '504':
+          description: Site could not be validated in time
+  '/api/program/{programId}/sites':
+    get:
+      tags:
+        - EDS Sites
+      summary: Get All Sites by programId
+      description: ''
+      operationId: getProgramSites
+      parameters:
+        - name: programId
+          in: path
+          required: true
+          type: string
+        - name: x-gw-ims-org-id
+          in: header
+          description: IMS organization ID that the request is being made under.
+          required: true
+          type: string
+        - name: Authorization
+          in: header
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          required: true
+          type: string
+        - name: x-api-key
+          in: header
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Sites retrieved
+          schema:
+            $ref: '#/definitions/SiteList'
+    post:
+      tags:
+        - EDS Sites
+      summary: Create Site
+      description: ''
+      operationId: createSite
+      parameters:
+        - name: programId
+          in: path
+          required: true
+          type: string
+        - name: x-gw-ims-org-id
+          in: header
+          description: IMS organization ID that the request is being made under.
+          required: true
+          type: string
+        - name: Authorization
+          in: header
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          required: true
+          type: string
+        - name: x-api-key
+          in: header
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          required: true
+          type: string
+      responses:
+        '201':
+          description: Site created
+          schema:
+            $ref: '#/definitions/Site'
+  '/api/program/{programId}/feedbacks':
     post:
       tags:
         - Programs
@@ -3462,16 +3701,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -3484,7 +3719,7 @@ paths:
           description: Invalid request
         '404':
           description: Application not found
-  /api/program/{programId}/newRelicUsers:
+  '/api/program/{programId}/newRelicUsers':
     get:
       tags:
         - Programs
@@ -3504,16 +3739,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -3524,33 +3755,23 @@ paths:
         '400':
           description: The request is malformed.
         '401':
-          description: >-
-            The request has not been applied because it lacks valid
-            authentication credentials for the target resource.
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
         '403':
           description: The requester is not authorized to access the resource.
         '405':
-          description: >-
-            Client sent a request using a HTTP method that the server doesn't
-            support.
+          description: Client sent a request using a HTTP method that the server doesn't support.
         '406':
-          description: >-
-            Unacceptable content type. Client sent an Accept header for a
-            content type which does not exist on the server.
+          description: Unacceptable content type. Client sent an Accept header for a content type which does not exist on the server.
         '422':
           description: Unprocessable Entity
         '500':
           description: This is an indicator of a server-side error.
         '502':
-          description: >-
-            This is an indicator that the back-end service did not send a valid
-            response.
+          description: This is an indicator that the back-end service did not send a valid response.
         '503':
           description: This is an indicator of a potential server overload.
         '504':
-          description: >-
-            This is an indicator that the back-end service did not complete a
-            response within an allowed time period.
+          description: This is an indicator that the back-end service did not complete a response within an allowed time period.
     patch:
       tags:
         - Programs
@@ -3576,16 +3797,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -3603,29 +3820,21 @@ paths:
         '400':
           description: The request is malformed.
         '401':
-          description: >-
-            The request has not been applied because it lacks valid
-            authentication credentials for the target resource.
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
         '403':
           description: The requester is not authorized to access the resource.
         '404':
           description: Program not found
         '406':
-          description: >-
-            Unacceptable content type. Client sent an Accept header for a
-            content type which does not exist on the server.
+          description: Unacceptable content type. Client sent an Accept header for a content type which does not exist on the server.
         '500':
           description: This is an indicator of a server-side error.
         '502':
-          description: >-
-            This is an indicator that the back-end service did not send a valid
-            response.
+          description: This is an indicator that the back-end service did not send a valid response.
         '503':
           description: This is an indicator of a potential server overload.
         '504':
-          description: >-
-            This is an indicator that the back-end service did not complete a
-            response within an allowed time period.
+          description: This is an indicator that the back-end service did not complete a response within an allowed time period.
   /api/tenants:
     get:
       tags:
@@ -3641,16 +3850,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -3658,7 +3863,7 @@ paths:
           description: Successful retrieval of tenant list
           schema:
             $ref: '#/definitions/TenantList'
-  /api/tenant/{tenantId}:
+  '/api/tenant/{tenantId}':
     get:
       tags:
         - Tenants
@@ -3678,16 +3883,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -3697,7 +3898,7 @@ paths:
             $ref: '#/definitions/Tenant'
         '404':
           description: Tenant not found
-  /api/tenant/{tenantId}/programs:
+  '/api/tenant/{tenantId}/programs':
     get:
       tags:
         - Programs
@@ -3717,16 +3918,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -3761,16 +3958,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -3785,14 +3978,12 @@ paths:
             $ref: '#/definitions/Program'
         '409':
           description: Program already exists.
-  /api/program/{programId}/regions:
+  '/api/program/{programId}/regions':
     get:
       tags:
         - Regions
       summary: Lists Regions
-      description: >-
-        Returns all Regions that can be used to create environments for this
-        program.
+      description: Returns all Regions that can be used to create environments for this program.
       operationId: getProgramRegions
       parameters:
         - name: programId
@@ -3807,16 +3998,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -3824,7 +4011,7 @@ paths:
           description: successful operation
           schema:
             $ref: '#/definitions/RegionsList'
-  /api/program/{programId}/networkInfrastructures:
+  '/api/program/{programId}/networkInfrastructures':
     get:
       tags:
         - Network infrastructure
@@ -3844,16 +4031,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -3888,16 +4071,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -3912,7 +4091,7 @@ paths:
             $ref: '#/definitions/NetworkInfrastructure'
         '404':
           description: Resource not found
-  /api/program/{programId}/networkInfrastructure/{networkInfrastructureId}:
+  '/api/program/{programId}/networkInfrastructure/{networkInfrastructureId}':
     get:
       tags:
         - Network infrastructure
@@ -3937,16 +4116,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -3986,16 +4161,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -4034,16 +4205,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -4059,7 +4226,7 @@ paths:
           description: Network Infrastructure cannot be deleted
         '404':
           description: Network Infrastructure not found
-  /api/program/{programId}/environment/{environmentId}/advancedNetworking:
+  '/api/program/{programId}/environment/{environmentId}/advancedNetworking':
     get:
       tags:
         - Environment Advanced Networking Configuration
@@ -4084,16 +4251,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -4133,16 +4296,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -4183,16 +4342,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -4204,7 +4359,7 @@ paths:
           description: Validation exception
         '404':
           description: Resource not found
-  /api/program/{programId}/contentSets:
+  '/api/program/{programId}/contentSets':
     get:
       tags:
         - ContentSets
@@ -4224,16 +4379,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -4268,16 +4419,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -4294,7 +4441,7 @@ paths:
           description: Bad request
         '404':
           description: Program not found
-  /api/program/{programId}/contentSet/{contentSetId}:
+  '/api/program/{programId}/contentSet/{contentSetId}':
     get:
       tags:
         - ContentSets
@@ -4319,16 +4466,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -4370,16 +4513,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -4420,16 +4559,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -4441,7 +4576,7 @@ paths:
           description: Bad request
         '404':
           description: Content set not found
-  /api/program/{programId}/contentFlows:
+  '/api/program/{programId}/contentFlows':
     get:
       tags:
         - ContentSets
@@ -4474,16 +4609,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -4493,7 +4624,7 @@ paths:
             $ref: '#/definitions/ContentFlowList'
         '400':
           description: Bad request
-  /api/program/{programId}/environment/{environmentId}/contentFlow:
+  '/api/program/{programId}/environment/{environmentId}/contentFlow':
     post:
       tags:
         - ContentSets
@@ -4524,16 +4655,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -4552,7 +4679,7 @@ paths:
           description: The requester is not authorized to access the resource.
         '404':
           description: Program not found
-  /api/program/{programId}/contentFlow/checkCompatibility:
+  '/api/program/{programId}/contentFlow/checkCompatibility':
     post:
       tags:
         - ContentSets
@@ -4578,16 +4705,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -4606,7 +4729,7 @@ paths:
             $ref: '#/definitions/BadRequestError'
         '404':
           description: Program not found
-  /api/program/{programId}/contentFlow/{contentFlowId}:
+  '/api/program/{programId}/contentFlow/{contentFlowId}':
     get:
       tags:
         - ContentSets
@@ -4631,16 +4754,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -4674,16 +4793,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -4693,7 +4808,7 @@ paths:
             $ref: '#/definitions/ContentFlow'
         '400':
           description: Bad request
-  /api/program/{programId}/contentFlow/{contentFlowId}/logs:
+  '/api/program/{programId}/contentFlow/{contentFlowId}/logs':
     get:
       tags:
         - ContentSets
@@ -4713,7 +4828,7 @@ paths:
           type: string
         - name: jobType
           in: query
-          description: Job type (import, export)
+          description: 'Job type (import, export)'
           required: true
           type: string
         - name: x-gw-ims-org-id
@@ -4723,16 +4838,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -4746,7 +4857,7 @@ paths:
             $ref: '#/definitions/BadRequestError'
         '404':
           description: Program not found.
-  /api/program/{programId}/contentFlow/{contentFlowId}/logs/download:
+  '/api/program/{programId}/contentFlow/{contentFlowId}/logs/download':
     get:
       tags:
         - ContentSets
@@ -4766,7 +4877,7 @@ paths:
           type: string
         - name: jobType
           in: query
-          description: Job type (import, export)
+          description: 'Job type (import, export)'
           required: true
           type: string
         - name: Accept
@@ -4780,16 +4891,12 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
+          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
+          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
           required: true
           type: string
       responses:
@@ -4804,1034 +4911,6 @@ paths:
             $ref: '#/definitions/BadRequestError'
         '404':
           description: Program not found.
-  /api/program/{programId}/domains:
-    get:
-      tags:
-        - Domain
-      summary: Get list of domains
-      description: ''
-      operationId: getDomain
-      parameters:
-        - name: programId
-          in: path
-          description: Identifier of program id
-          required: true
-          type: string
-        - name: name
-          in: query
-          description: Domain name
-          required: false
-          type: string
-        - name: anyVerified
-          in: query
-          description: Filter any verified
-          required: false
-          type: boolean
-        - name: isTxt
-          in: query
-          description: Is TXT verified
-          required: false
-          type: boolean
-        - name: isAcme
-          in: query
-          description: Is ACME verified
-          required: false
-          type: boolean
-        - name: x-gw-ims-org-id
-          in: header
-          description: IMS organization ID that the request is being made under.
-          required: true
-          type: string
-        - name: Authorization
-          in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
-          required: true
-          type: string
-        - name: x-api-key
-          in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
-          required: true
-          type: string
-      responses:
-        '200':
-          description: List of domains received
-          schema:
-            $ref: '#/definitions/Domain'
-    post:
-      tags:
-        - Domain
-      summary: Create a domain
-      description: ''
-      operationId: createDomain
-      parameters:
-        - name: programId
-          in: path
-          description: Identifier of program
-          required: true
-          type: string
-        - in: body
-          name: body
-          description: Payload for creating a domain
-          required: true
-          schema:
-            $ref: '#/definitions/DomainCreate'
-        - name: x-gw-ims-org-id
-          in: header
-          description: IMS organization ID that the request is being made under.
-          required: true
-          type: string
-        - name: Authorization
-          in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
-          required: true
-          type: string
-        - name: x-api-key
-          in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
-          required: true
-          type: string
-        - name: Content-Type
-          in: header
-          description: Must always be application/json
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Domain created
-          schema:
-            $ref: '#/definitions/Domain'
-        '404':
-          description: Program not found
-        '409':
-          description: Domain already exists
-  /api/program/{programId}/domain/{domain-id}:
-    get:
-      tags:
-        - Domain
-      summary: Get domain
-      description: ''
-      operationId: getDomain
-      parameters:
-        - name: programId
-          in: path
-          description: Identifier of program id
-          required: true
-          type: string
-        - name: domain-id
-          in: path
-          description: Identifier of domain id
-          required: true
-          type: string
-        - name: x-gw-ims-org-id
-          in: header
-          description: IMS organization ID that the request is being made under.
-          required: true
-          type: string
-        - name: Authorization
-          in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
-          required: true
-          type: string
-        - name: x-api-key
-          in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Domain received
-          schema:
-            $ref: '#/definitions/Domain'
-        '404':
-          description: Domain not found
-    put:
-      tags:
-        - Domain
-      summary: Update domain
-      description: ''
-      operationId: modifyDomain
-      parameters:
-        - name: programId
-          in: path
-          description: Identifier of program id
-          required: true
-          type: string
-        - name: domain-id
-          in: path
-          description: Identifier of domain id
-          required: true
-          type: string
-        - in: body
-          name: body
-          description: Domain Update Body
-          required: true
-          schema:
-            $ref: '#/definitions/UpdateaDomain''snameorlabel'
-        - name: x-gw-ims-org-id
-          in: header
-          description: IMS organization ID that the request is being made under.
-          required: true
-          type: string
-        - name: Authorization
-          in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
-          required: true
-          type: string
-        - name: x-api-key
-          in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
-          required: true
-          type: string
-        - name: Content-Type
-          in: header
-          description: Must always be application/json
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Domain updated
-          schema:
-            $ref: '#/definitions/Domain'
-        '404':
-          description: Program not found
-    delete:
-      tags:
-        - Domain
-      summary: Delete a domain
-      description: ''
-      operationId: deleteDomain
-      parameters:
-        - name: programId
-          in: path
-          description: Identifier of program id
-          required: true
-          type: string
-        - name: domain-id
-          in: path
-          description: Identifier of domain id
-          required: true
-          type: string
-        - name: x-gw-ims-org-id
-          in: header
-          description: IMS organization ID that the request is being made under.
-          required: true
-          type: string
-        - name: Authorization
-          in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
-          required: true
-          type: string
-        - name: x-api-key
-          in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Domain deleted
-          schema:
-            $ref: '#/definitions/Response'
-  /api/program/{programId}/domain/{domain-id}/validate:
-    put:
-      tags:
-        - Domain
-      summary: Check validation
-      description: ''
-      operationId: domainValidationToken
-      parameters:
-        - name: programId
-          in: path
-          description: Identifier of program id
-          required: true
-          type: string
-        - name: domain-id
-          in: path
-          description: Identifier of domain id
-          required: true
-          type: string
-        - in: body
-          name: body
-          description: Payload for validation operation
-          required: true
-          schema:
-            $ref: '#/definitions/DomainTokenValidationBody'
-        - name: x-gw-ims-org-id
-          in: header
-          description: IMS organization ID that the request is being made under.
-          required: true
-          type: string
-        - name: Authorization
-          in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
-          required: true
-          type: string
-        - name: x-api-key
-          in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
-          required: true
-          type: string
-        - name: Content-Type
-          in: header
-          description: Must always be application/json
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Validation is completed
-          schema:
-            $ref: '#/definitions/Domain'
-        '404':
-          description: Program not found
-  /api/program/{programId}/domain/{domain-id}/validation:
-    post:
-      tags:
-        - Domain
-      summary: Creates validation token
-      description: ''
-      operationId: domainValidationToken
-      parameters:
-        - name: programId
-          in: path
-          description: Identifier of program id
-          required: true
-          type: string
-        - name: domain-id
-          in: path
-          description: Identifier of domain id
-          required: true
-          type: string
-        - in: body
-          name: body
-          description: Payload for validation operation
-          required: true
-          schema:
-            $ref: '#/definitions/DomainTokenValidationBody'
-        - name: x-gw-ims-org-id
-          in: header
-          description: IMS organization ID that the request is being made under.
-          required: true
-          type: string
-        - name: Authorization
-          in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
-          required: true
-          type: string
-        - name: x-api-key
-          in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
-          required: true
-          type: string
-        - name: Content-Type
-          in: header
-          description: Must always be application/json
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Created validation token
-          schema:
-            $ref: '#/definitions/Domain'
-        '404':
-          description: Program Not found
-  /api/program/{programId}/domain-mapping/{domainMappingId}:
-    get:
-      tags:
-        - Domain Mappings - CDN Configurations
-      summary: Get domain mapping
-      description: ''
-      operationId: getDomainMappingById
-      parameters:
-        - name: programId
-          in: path
-          description: Identifier of program
-          required: true
-          type: integer
-          format: int64
-        - name: domainMappingId
-          in: path
-          description: Identifier of domain mapping
-          required: true
-          type: integer
-          format: int64
-        - name: x-gw-ims-org-id
-          in: header
-          description: IMS organization ID that the request is being made under.
-          required: true
-          type: string
-        - name: Authorization
-          in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
-          required: true
-          type: string
-        - name: x-api-key
-          in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Domain Mapping retrieved
-          schema:
-            $ref: '#/definitions/DomainMapping'
-        '404':
-          description: Domain Mapping not found
-    put:
-      tags:
-        - Domain Mappings - CDN Configurations
-      summary: Update domain mapping
-      description: ''
-      operationId: updateDomainMapping
-      parameters:
-        - name: programId
-          in: path
-          description: Identifier of program
-          required: true
-          type: integer
-          format: int64
-        - name: domainMappingId
-          in: path
-          description: Identifier of domain mapping
-          required: true
-          type: integer
-          format: int64
-        - in: body
-          name: body
-          description: Payload for updating a domain mapping
-          required: true
-          schema:
-            $ref: '#/definitions/Updateadomainmapping'
-        - name: x-gw-ims-org-id
-          in: header
-          description: IMS organization ID that the request is being made under.
-          required: true
-          type: string
-        - name: Authorization
-          in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
-          required: true
-          type: string
-        - name: x-api-key
-          in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
-          required: true
-          type: string
-        - name: Content-Type
-          in: header
-          description: Must always be application/json
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Domain Mapping updated
-          schema:
-            $ref: '#/definitions/DomainMapping'
-        '404':
-          description: Domain Mapping not found
-    delete:
-      tags:
-        - Domain Mappings - CDN Configurations
-      summary: Delete domain mapping
-      description: ''
-      operationId: deleteDomainMapping
-      parameters:
-        - name: programId
-          in: path
-          description: Identifier of program
-          required: true
-          type: integer
-          format: int64
-        - name: domainMappingId
-          in: path
-          description: Identifier of domain mapping
-          required: true
-          type: integer
-          format: int64
-        - name: x-gw-ims-org-id
-          in: header
-          description: IMS organization ID that the request is being made under.
-          required: true
-          type: string
-        - name: Authorization
-          in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
-          required: true
-          type: string
-        - name: x-api-key
-          in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Domain Mapping deleted
-          schema:
-            $ref: '#/definitions/DomainMapping'
-        '404':
-          description: Domain Mapping not found
-  /api/program/{programId}/domain-mapping/{domainMappingId}/verify:
-    put:
-      tags:
-        - Domain Mappings - CDN Configurations
-      summary: Check if customer made the required DNS changes
-      description: ''
-      operationId: validateHelixDomain
-      parameters:
-        - name: programId
-          in: path
-          description: Identifier of program
-          required: true
-          type: integer
-          format: int64
-        - name: domainMappingId
-          in: path
-          description: Identifier of domain mapping
-          required: true
-          type: integer
-          format: int64
-        - name: x-gw-ims-org-id
-          in: header
-          description: IMS organization ID that the request is being made under.
-          required: true
-          type: string
-        - name: Authorization
-          in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
-          required: true
-          type: string
-        - name: x-api-key
-          in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
-          required: true
-          type: string
-      responses:
-        '200':
-          description: DNS changes were successfully made
-          schema:
-            $ref: '#/definitions/DomainMapping'
-        '404':
-          description: Program not found
-  /api/program/{programId}/domain-mappings:
-    get:
-      tags:
-        - Domain Mappings - CDN Configurations
-      summary: List of domain mappings
-      description: ''
-      operationId: getAllDomainMappingsByProgramId
-      parameters:
-        - name: programId
-          in: path
-          description: Identifier of program
-          required: true
-          type: integer
-          format: int64
-        - name: x-gw-ims-org-id
-          in: header
-          description: IMS organization ID that the request is being made under.
-          required: true
-          type: string
-        - name: Authorization
-          in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
-          required: true
-          type: string
-        - name: x-api-key
-          in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
-          required: true
-          type: string
-      responses:
-        '200':
-          description: List of domain mappings retrieved
-          schema:
-            $ref: '#/definitions/DomainMappingList'
-    post:
-      tags:
-        - Domain Mappings - CDN Configurations
-      summary: Create domain mapping
-      description: ''
-      operationId: createDomainMapping
-      parameters:
-        - name: programId
-          in: path
-          description: Identifier of program
-          required: true
-          type: integer
-          format: int64
-        - in: body
-          name: body
-          description: Payload for creating a domain mapping
-          required: true
-          schema:
-            $ref: '#/definitions/Createanewdomainmapping'
-        - name: x-gw-ims-org-id
-          in: header
-          description: IMS organization ID that the request is being made under.
-          required: true
-          type: string
-        - name: Authorization
-          in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
-          required: true
-          type: string
-        - name: x-api-key
-          in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
-          required: true
-          type: string
-        - name: Content-Type
-          in: header
-          description: Must always be application/json
-          required: true
-          type: string
-      responses:
-        '200':
-          description: successful operation
-          schema:
-            $ref: '#/definitions/DomainMapping'
-        '201':
-          description: Domain Mapping created
-          schema:
-            $ref: '#/definitions/DomainMapping'
-  /api/program/{programId}/environment/{environmentId}/domain-mappings:
-    get:
-      tags:
-        - Domain Mappings - CDN Configurations
-      summary: List of domain mappings by environment
-      description: ''
-      operationId: getAllDomainMappingsByProgramIdAndEnvironmentId
-      parameters:
-        - name: programId
-          in: path
-          description: Identifier of program
-          required: true
-          type: integer
-          format: int64
-        - name: environmentId
-          in: path
-          description: Identifier of environment
-          required: true
-          type: integer
-          format: int64
-        - name: x-gw-ims-org-id
-          in: header
-          description: IMS organization ID that the request is being made under.
-          required: true
-          type: string
-        - name: Authorization
-          in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
-          required: true
-          type: string
-        - name: x-api-key
-          in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
-          required: true
-          type: string
-      responses:
-        '200':
-          description: List of domain mappings by environment retrieved
-          schema:
-            $ref: '#/definitions/DomainMappingList'
-  /api/program/{programId}/site/{siteId}/domain-mappings:
-    get:
-      tags:
-        - Domain Mappings - CDN Configurations
-      summary: List of domain mappings by EDS site
-      description: ''
-      operationId: getAllDomainMappingsByProgramIdAndSiteId
-      parameters:
-        - name: programId
-          in: path
-          description: Identifier of program
-          required: true
-          type: integer
-          format: int64
-        - name: siteId
-          in: path
-          description: Identifier of EDS site
-          required: true
-          type: integer
-          format: int64
-        - name: x-gw-ims-org-id
-          in: header
-          description: IMS organization ID that the request is being made under.
-          required: true
-          type: string
-        - name: Authorization
-          in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
-          required: true
-          type: string
-        - name: x-api-key
-          in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
-          required: true
-          type: string
-      responses:
-        '200':
-          description: List of domain mappings by environment retrieved
-          schema:
-            $ref: '#/definitions/DomainMappingList'
-  /api/program/{programId}/dv-certificates:
-    post:
-      tags:
-        - SSL Certificates
-      summary: Create DV certificate
-      description: ''
-      operationId: createDvCertificate
-      parameters:
-        - name: programId
-          in: path
-          description: Identifier of the program
-          required: true
-          type: integer
-          format: int64
-        - in: body
-          name: body
-          description: Payload for creating the DV certificate
-          required: true
-          schema:
-            $ref: '#/definitions/CreateDvCertificateBody'
-        - name: x-gw-ims-org-id
-          in: header
-          description: IMS organization ID that the request is being made under.
-          required: true
-          type: string
-        - name: Authorization
-          in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
-          required: true
-          type: string
-        - name: x-api-key
-          in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
-          required: true
-          type: string
-        - name: Content-Type
-          in: header
-          description: Must always be application/json
-          required: true
-          type: string
-      responses:
-        '200':
-          description: successful operation
-          schema:
-            $ref: '#/definitions/SslCertificate'
-        '201':
-          description: Created DV certificate
-          schema:
-            $ref: '#/definitions/SslCertificate'
-  /api/program/{programId}/site/{siteId}:
-    get:
-      tags:
-        - EDS Sites
-      summary: Get Site by Id
-      description: ''
-      operationId: retrieveSite
-      parameters:
-        - name: programId
-          in: path
-          required: true
-          type: string
-        - name: siteId
-          in: path
-          required: true
-          type: integer
-          format: int64
-        - name: x-gw-ims-org-id
-          in: header
-          description: IMS organization ID that the request is being made under.
-          required: true
-          type: string
-        - name: Authorization
-          in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
-          required: true
-          type: string
-        - name: x-api-key
-          in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Site retrieved
-          schema:
-            $ref: '#/definitions/Site'
-        '404':
-          description: Site could not be found
-    put:
-      tags:
-        - EDS Sites
-      summary: Update Site
-      description: ''
-      operationId: updateSite
-      parameters:
-        - name: programId
-          in: path
-          required: true
-          type: string
-        - name: siteId
-          in: path
-          required: true
-          type: integer
-          format: int64
-        - name: x-gw-ims-org-id
-          in: header
-          description: IMS organization ID that the request is being made under.
-          required: true
-          type: string
-        - name: Authorization
-          in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
-          required: true
-          type: string
-        - name: x-api-key
-          in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Site updated
-          schema:
-            $ref: '#/definitions/Site'
-        '404':
-          description: Site could not be found
-    delete:
-      tags:
-        - EDS Sites
-      summary: Delete Site
-      description: ''
-      operationId: deleteSite
-      parameters:
-        - name: programId
-          in: path
-          required: true
-          type: string
-        - name: siteId
-          in: path
-          required: true
-          type: integer
-          format: int64
-        - name: x-gw-ims-org-id
-          in: header
-          description: IMS organization ID that the request is being made under.
-          required: true
-          type: string
-        - name: Authorization
-          in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
-          required: true
-          type: string
-        - name: x-api-key
-          in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Site deleted
-          schema:
-            $ref: '#/definitions/Site'
-        '404':
-          description: Site could not be found
-  /api/program/{programId}/site/{siteId}/validate:
-    put:
-      tags:
-        - EDS Sites
-      summary: Validate Site
-      description: ''
-      operationId: validateSite
-      parameters:
-        - name: programId
-          in: path
-          description: Identifier of the program
-          required: true
-          type: string
-        - name: siteId
-          in: path
-          description: Identifier of the site
-          required: true
-          type: integer
-          format: int64
-        - name: x-gw-ims-org-id
-          in: header
-          description: IMS organization ID that the request is being made under.
-          required: true
-          type: string
-        - name: Authorization
-          in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
-          required: true
-          type: string
-        - name: x-api-key
-          in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Site validated
-          schema:
-            $ref: '#/definitions/Site'
-        '400':
-          description: Site could not be validated. CloudManager challenge does not match
-        '500':
-          description: Internal Server Error
-        '504':
-          description: Site could not be validated in time
-  /api/program/{programId}/sites:
-    get:
-      tags:
-        - EDS Sites
-      summary: Get All Sites by programId
-      description: ''
-      operationId: getProgramSites
-      parameters:
-        - name: programId
-          in: path
-          required: true
-          type: string
-        - name: x-gw-ims-org-id
-          in: header
-          description: IMS organization ID that the request is being made under.
-          required: true
-          type: string
-        - name: Authorization
-          in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
-          required: true
-          type: string
-        - name: x-api-key
-          in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Sites retrieved
-          schema:
-            $ref: '#/definitions/SiteList'
-    post:
-      tags:
-        - EDS Sites
-      summary: Create Site
-      description: ''
-      operationId: createSite
-      parameters:
-        - name: programId
-          in: path
-          required: true
-          type: string
-        - name: x-gw-ims-org-id
-          in: header
-          description: IMS organization ID that the request is being made under.
-          required: true
-          type: string
-        - name: Authorization
-          in: header
-          description: >-
-            Bearer [token] - An access token for the technical account created
-            through integration with Adobe IO
-          required: true
-          type: string
-        - name: x-api-key
-          in: header
-          description: >-
-            IMS Client ID (API Key) which is subscribed to consume services on
-            console.adobe.io
-          required: true
-          type: string
-      responses:
-        '201':
-          description: Site created
-          schema:
-            $ref: '#/definitions/Site'
 definitions:
   ProgramList:
     type: object
@@ -5912,7 +4991,7 @@ definitions:
         type: object
         readOnly: true
         properties:
-          http://ns.adobe.com/adobecloud/rel/tenant:
+          'http://ns.adobe.com/adobecloud/rel/tenant':
             description: The tenant this program belongs to
             $ref: '#/definitions/HalLink'
           self:
@@ -5935,7 +5014,7 @@ definitions:
         description: Name of the program
         minLength: 0
         maxLength: 64
-        pattern: (?=.*[a-zA-Z])[-+!'"/#$%&*.,;:()’@-}À-ÿ– 0-9]*
+        pattern: '(?=.*[a-zA-Z])[-+!''"/#$%&*.,;:()’@-}À-ÿ– 0-9]*'
       enabled:
         type: boolean
         description: Whether this Program has been enabled for Cloud Manager usage
@@ -5982,30 +5061,27 @@ definitions:
         type: object
         readOnly: true
         properties:
-          http://ns.adobe.com/adobecloud/rel/pipelines:
+          'http://ns.adobe.com/adobecloud/rel/pipelines':
             description: Pipelines defined in the program
             $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/environments:
+          'http://ns.adobe.com/adobecloud/rel/environments':
             description: The environments linked to this program.
             $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/repositories:
+          'http://ns.adobe.com/adobecloud/rel/repositories':
             description: The repositories linked to this program.
             $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/ipAllowlists:
+          'http://ns.adobe.com/adobecloud/rel/ipAllowlists':
             description: The IP allowlists linked to this program.
             $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/certificates:
+          'http://ns.adobe.com/adobecloud/rel/certificates':
             description: The SSL certificates linked to this program.
             $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/domainNames:
-            description: The domain names linked to this program.
-            $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/tenant:
+          'http://ns.adobe.com/adobecloud/rel/tenant':
             description: The tenant this program belongs to
             $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/networkInfrastructures:
+          'http://ns.adobe.com/adobecloud/rel/networkInfrastructures':
             $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/regions:
+          'http://ns.adobe.com/adobecloud/rel/regions':
             description: The regions available for this program.
             $ref: '#/definitions/HalLink'
           self:
@@ -6065,10 +5141,7 @@ definitions:
       trigger:
         type: string
         example: MANUAL
-        description: >-
-          How should the execution be triggered. ON_COMMIT: each time one or
-          more commits are pushed and the Pipeline is idle then a execution is
-          triggered. MANUAL: triggerd through UI or API.
+        description: 'How should the execution be triggered. ON_COMMIT: each time one or more commits are pushed and the Pipeline is idle then a execution is triggered. MANUAL: triggerd through UI or API.'
         enum:
           - ON_COMMIT
           - MANUAL
@@ -6118,25 +5191,25 @@ definitions:
         type: object
         readOnly: true
         properties:
-          http://ns.adobe.com/adobecloud/rel/program:
+          'http://ns.adobe.com/adobecloud/rel/program':
             description: The Program this pipeline belongs to.
             $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/execution:
+          'http://ns.adobe.com/adobecloud/rel/execution':
             description: Current pipeline execution if any
             $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/execution/id:
+          'http://ns.adobe.com/adobecloud/rel/execution/id':
             description: Get pipeline execution by id
             $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/executions:
+          'http://ns.adobe.com/adobecloud/rel/executions':
             description: Get all historic executions for this pipeline.
             $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/variables:
+          'http://ns.adobe.com/adobecloud/rel/variables':
             description: Custom pipeline variables
             $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/rollbackLastSuccessfulExecution:
+          'http://ns.adobe.com/adobecloud/rel/rollbackLastSuccessfulExecution':
             description: Start a CI/CD rollback execution
             $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/cache:
+          'http://ns.adobe.com/adobecloud/rel/cache':
             description: Pipeline cache
             $ref: '#/definitions/HalLink'
           self:
@@ -6162,35 +5235,29 @@ definitions:
           - DEPLOY
       repositoryId:
         type: string
-        description: >-
-          Identifier of the source repository. The code from this repository
-          will be build at the start of this phase. 
-
+        description: |-
+          Identifier of the source repository. The code from this repository will be build at the start of this phase. 
           Mandatory if type=BUILD
       branch:
         type: string
-        description: >-
-          Name of the tracked branch or a fully qualified git tag (e.g.
-          refs/tags/v1). 
+        description: |-
+          Name of the tracked branch or a fully qualified git tag (e.g. refs/tags/v1). 
            Assumed to be `master` if missing.
       environmentId:
         type: string
         description: Identifier of the target environment. Mandatory if type=DEPLOY
       environmentType:
         type: string
-        description: Type of environment (for example stage or prod, readOnly = true)
+        description: 'Type of environment (for example stage or prod, readOnly = true)'
         enum:
           - dev
           - stage
           - prod
           - rde
           - preprod
-          - devxl
       steps:
         type: array
-        description: >-
-          Steps to be included in the phase in execution order. Might be added
-          or not, depending on permissions or configuration
+        description: 'Steps to be included in the phase in execution order. Might be added or not, depending on permissions or configuration'
         items:
           $ref: '#/definitions/PipelineStep'
     description: Describes a phase of a pipeline
@@ -6271,9 +5338,7 @@ definitions:
           - PUSH_UPGRADES
       pipelineExecutionMode:
         type: string
-        description: >-
-          The mode in which the execution occurred. EMERGENCY mode will skip
-          certain steps and is only available to select AMS customers
+        description: The mode in which the execution occurred. EMERGENCY mode will skip certain steps and is only available to select AMS customers
         enum:
           - NORMAL
           - EMERGENCY
@@ -6308,10 +5373,10 @@ definitions:
         type: object
         readOnly: true
         properties:
-          http://ns.adobe.com/adobecloud/rel/program:
+          'http://ns.adobe.com/adobecloud/rel/program':
             description: Get the program of the execution
             $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/pipeline:
+          'http://ns.adobe.com/adobecloud/rel/pipeline':
             description: Get the pipeline of the execution
             $ref: '#/definitions/HalLink'
           self:
@@ -6380,37 +5445,30 @@ definitions:
         type: object
         readOnly: true
         properties:
-          http://ns.adobe.com/adobecloud/rel/execution:
+          'http://ns.adobe.com/adobecloud/rel/execution':
             $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/pipeline:
+          'http://ns.adobe.com/adobecloud/rel/pipeline':
             description: Get the pipeline of the execution
             $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/pipeline/logs:
+          'http://ns.adobe.com/adobecloud/rel/pipeline/logs':
             $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/pipeline/metrics:
+          'http://ns.adobe.com/adobecloud/rel/pipeline/metrics':
             $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/pipeline/reExecute:
+          'http://ns.adobe.com/adobecloud/rel/pipeline/reExecute':
             $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/pipeline/advance:
-            description: >-
-              Post to this link in order to advance the pipeline, if paused and
-              waiting for user interaction. Link is present in output only in
-              that case.
+          'http://ns.adobe.com/adobecloud/rel/pipeline/advance':
+            description: 'Post to this link in order to advance the pipeline, if paused and waiting for user interaction. Link is present in output only in that case.'
             $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/pipeline/cancel:
-            description: >-
-              Post to this link in order to cancel the pipeline. Link is present
-              in output only in that case.
+          'http://ns.adobe.com/adobecloud/rel/pipeline/cancel':
+            description: Post to this link in order to cancel the pipeline. Link is present in output only in that case.
             $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/program:
+          'http://ns.adobe.com/adobecloud/rel/program':
             description: Get the program of the execution
             $ref: '#/definitions/HalLink'
           self:
             $ref: '#/definitions/HalLink'
             description: This object's representation
-    description: >-
-      Describes the status of a particular pipeline execution step for display
-      purposes
+    description: Describes the status of a particular pipeline execution step for display purposes
   PipelineExecutionListRepresentation:
     type: object
     properties:
@@ -6538,7 +5596,7 @@ definitions:
         type: string
         example: AcmeCorp Dev1 Environment
         description: Name of the environment
-        pattern: (?=.*[a-zA-Z])[-+!'"/#$%&*.,;()@-} 0-9]*
+        pattern: '(?=.*[a-zA-Z])[-+!''"/#$%&*.,;()@-} 0-9]*'
       description:
         type: string
         example: This is our primary development environment
@@ -6553,7 +5611,6 @@ definitions:
           - prod
           - rde
           - preprod
-          - devxl
       status:
         type: string
         example: creating
@@ -6572,7 +5629,6 @@ definitions:
           - resetting
           - reset_failed
           - degraded
-          - hibernated
       region:
         type: string
         example: va7
@@ -6586,30 +5642,30 @@ definitions:
         type: object
         readOnly: true
         properties:
-          http://ns.adobe.com/adobecloud/rel/program:
+          'http://ns.adobe.com/adobecloud/rel/program':
             description: The Program this environment belongs to.
             $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/pipeline:
-            description: The Pipeline this environment is assigned to, if any
+          'http://ns.adobe.com/adobecloud/rel/pipeline':
+            description: 'The Pipeline this environment is assigned to, if any'
             $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/author:
+          'http://ns.adobe.com/adobecloud/rel/author':
             description: Author URL
             $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/publish:
+          'http://ns.adobe.com/adobecloud/rel/publish':
             description: Publish URL
             $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/preview:
+          'http://ns.adobe.com/adobecloud/rel/preview':
             description: Publish URL
             $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/developerConsole:
+          'http://ns.adobe.com/adobecloud/rel/developerConsole':
             description: Developer Console URL
             $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/logs:
+          'http://ns.adobe.com/adobecloud/rel/logs':
             $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/variables:
+          'http://ns.adobe.com/adobecloud/rel/variables':
             description: Custom environment variables
             $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/advancedNetworking:
+          'http://ns.adobe.com/adobecloud/rel/advancedNetworking':
             $ref: '#/definitions/HalLink'
           self:
             $ref: '#/definitions/HalLink'
@@ -6628,16 +5684,16 @@ definitions:
         description: description
       repositoryUrl:
         type: string
-        example: https://git.cloudmanager.adobe.com/weretailprod/we-retail-global
+        example: 'https://git.cloudmanager.adobe.com/weretailprod/we-retail-global'
         description: Repository Url.
       _links:
         type: object
         readOnly: true
         properties:
-          http://ns.adobe.com/adobecloud/rel/program:
+          'http://ns.adobe.com/adobecloud/rel/program':
             description: The Program the repository belongs to
             $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/branches:
+          'http://ns.adobe.com/adobecloud/rel/branches':
             description: List of branches in this repository
             $ref: '#/definitions/HalLink'
           self:
@@ -6698,10 +5754,10 @@ definitions:
         type: object
         readOnly: true
         properties:
-          http://ns.adobe.com/adobecloud/rel/program:
+          'http://ns.adobe.com/adobecloud/rel/program':
             description: Program
             $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/repository:
+          'http://ns.adobe.com/adobecloud/rel/repository':
             description: Repository
             $ref: '#/definitions/HalLink'
     description: Represents a Git Branch
@@ -6793,7 +5849,7 @@ definitions:
         description: HTTP status code of the response.
       type:
         type: string
-        example: http://ns.adobe.com/adobecloud/error
+        example: 'http://ns.adobe.com/adobecloud/error'
         description: Error type identifier.
       title:
         type: string
@@ -6836,10 +5892,10 @@ definitions:
         type: object
         readOnly: true
         properties:
-          http://ns.adobe.com/adobecloud/rel/logs/download:
+          'http://ns.adobe.com/adobecloud/rel/logs/download':
             description: Download Logs link
             $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/logs/tail:
+          'http://ns.adobe.com/adobecloud/rel/logs/tail':
             description: Tail Log link
             $ref: '#/definitions/HalLink'
     description: Log from Environment
@@ -6867,7 +5923,7 @@ definitions:
         type: object
         readOnly: true
         properties:
-          http://ns.adobe.com/adobecloud/rel/program:
+          'http://ns.adobe.com/adobecloud/rel/program':
             description: The Application this environment belongs to.
             $ref: '#/definitions/HalLink'
           self:
@@ -6889,50 +5945,25 @@ definitions:
       name:
         type: string
         example: MY_VAR1
-        description: >-
-          Name of the variable. Can only consist of a-z, A-Z, _ and 0-9 and
-          cannot begin with a number.
-        minLength: 2
-        maxLength: 100
+        description: 'Name of the variable. Can only consist of a-z, A-Z, _ and 0-9 and cannot begin with a number.'
         pattern: '[a-zA-Z_][a-zA-Z_0-9]*'
       value:
         type: string
         example: myValue
-        description: >-
-          Value of the variable. Read-Write for non-secrets, write-only for
-          secrets. The length of `secretString` values must be less than 500
-          characters. An empty value causes a variable to be deleted.
-        minLength: 0
-        maxLength: 2048
+        description: 'Value of the variable. Read-Write for non-secrets, write-only for secrets. The length of `secretString` values must be less than 500 characters. An empty value causes a variable to be deleted.'
       type:
         type: string
         example: string
-        description: >-
-          Type of the variable. Default `string` if missing. `secretString`
-          variables are encrypted at rest. The type of a variable be changed
-          after creation; the variable must be deleted and recreated.
+        description: Type of the variable. Default `string` if missing. `secretString` variables are encrypted at rest. The type of a variable be changed after creation; the variable must be deleted and recreated.
         enum:
           - string
           - secretString
       service:
-        type: string
-        example: author
-        description: >-
-          Service of the variable. When not provided, the variable applies to
-          all services. Currently the values 'author', 'publish', and 'preview'
-          are supported. Note - this value is case-sensitive.
+        description: 'Service of the variable. When not provided, the variable applies to all services. Currently the values ''author'', ''publish'', and ''preview'' are supported. Note - this value is case-sensitive.'
       status:
         type: string
         example: ready
         description: Status of the variable
-        enum:
-          - creating
-          - ready
-          - deleting
-          - deleted
-          - updating
-          - failed
-          - deleted_failed
     description: A named value than can be set on an Environment or Pipeline
   VariableList:
     type: object
@@ -6940,7 +5971,6 @@ definitions:
       _totalNumberOfItems:
         type: integer
         format: int32
-        example: 1
         description: The total number of embedded items
       _embedded:
         type: object
@@ -6948,11 +5978,7 @@ definitions:
         properties:
           variables:
             type: array
-            example: >-
-              [{ 'name':'variable1Name', 'value':'variable1Value'}, {
-              'name':'variable1Name', 'value':'variable1Value',
-              'service':'author'}, { 'name':'variable2Name',
-              'type':'secretString', 'value':'variable2SecretValue'}]
+            example: '[{ ''name'':''variable1Name'', ''value'':''variable1Value''}, { ''name'':''variable1Name'', ''value'':''variable1Value'', ''service'':''author''}, { ''name'':''variable2Name'', ''type'':''secretString'', ''value'':''variable2SecretValue''}]'
             description: Variables set on environment
             items:
               $ref: '#/definitions/Variable'
@@ -6960,101 +5986,28 @@ definitions:
         type: object
         readOnly: true
         properties:
-          http://ns.adobe.com/adobecloud/rel/environment:
-            description: The environment holding the variables
+          'http://ns.adobe.com/adobecloud/rel/edgeEnvironment':
+            description: The edge environment holding the variables
             $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/pipeline:
-            description: The pipeline holding the variables
-            $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/program:
+          'http://ns.adobe.com/adobecloud/rel/program':
             description: The Program
             $ref: '#/definitions/HalLink'
           self:
             $ref: '#/definitions/HalLink'
             description: This object's representation
-          http://ns.adobe.com/adobecloud/rel/edgeEnvironment:
-            description: The edge environment holding the variables
-            $ref: '#/definitions/HalLink'
   RegionDeployment:
     type: object
     properties:
-      cluster:
-        type: string
-        example: ethos13stageva7
-        description: The cluster where this deployment happens
-      namespace:
-        type: string
-        example: ns-team-aem
-        description: The namespace in which this deployment happens
-      createdAt:
-        type: string
-        format: date-time
-        description: Created time
-      updatedAt:
-        type: string
-        format: date-time
-        description: Date of last change
-      id:
-        type: string
-        description: identifier of a region deployment
-      environmentId:
-        type: string
-        description: identifier of an environment
-      region:
-        type: string
-        example: va7
-        description: Region name of the deployment
-      integrations:
-        description: region integrations
-        $ref: '#/definitions/EnvironmentRegionintegrations'
-      status:
-        type: string
-        description: Status of the region deployment
-        enum:
-          - PENDING
-          - PROGRESSING
-          - FAILED
-          - COMPLETE
-          - DELETING
-          - DELETED
-          - DELETION_FAILED
-          - TO_DELETE
-          - DEPLOY_FAILED
-          - DEPLOY_TIMEOUT
-      type:
-        type: string
-        example: primary
-        description: Type of the region deployment
-        enum:
-          - PRIMARY
-          - SECONDARY
-      _links:
-        type: object
-        readOnly: true
-        properties:
-          http://ns.adobe.com/adobecloud/rel/flow:
-            $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/kubernetesCluster:
-            description: Get the Kubernetes Cluster in which this deployment happens
-            $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/kubernetesNamespace:
-            description: Get the Kubernetes Namespace in which this deployment happens
-            $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/region:
-            description: Region being used for this deployment
-            $ref: '#/definitions/HalLink'
-          self:
-            $ref: '#/definitions/HalLink'
-            description: This object's representation
       regionName:
         type: string
       clusterName:
         type: string
       namespaceName:
         type: string
+      type:
+        type: string
       dataStore:
         $ref: '#/definitions/DataStore'
-    description: describes region deployments for an environment
   RegionDeploymentList:
     type: object
     properties:
@@ -7117,7 +6070,7 @@ definitions:
         type: object
         readOnly: true
         properties:
-          http://ns.adobe.com/adobecloud/rel/program:
+          'http://ns.adobe.com/adobecloud/rel/program':
             description: The Application this content set belongs to.
             $ref: '#/definitions/HalLink'
           self:
@@ -7195,7 +6148,7 @@ definitions:
         description: Destination environment name
       tier:
         type: string
-        description: The tier, for example author
+        description: 'The tier, for example author'
       status:
         type: string
         description: Status of the flows
@@ -7209,16 +6162,16 @@ definitions:
         type: object
         readOnly: true
         properties:
-          http://ns.adobe.com/adobecloud/rel/contentSet:
+          'http://ns.adobe.com/adobecloud/rel/contentSet':
             description: The Content set for this flow.
             $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/program:
+          'http://ns.adobe.com/adobecloud/rel/program':
             description: The Application this content set belongs to.
             $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/environment:
+          'http://ns.adobe.com/adobecloud/rel/environment':
             description: The source Environment this content flow is copying from.
             $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/destEnvironment:
+          'http://ns.adobe.com/adobecloud/rel/destEnvironment':
             description: The destination Environment this content flow is copying to.
             $ref: '#/definitions/HalLink'
           self:
@@ -7396,38 +6349,15 @@ definitions:
       name:
         type: string
         description: 'Name of the log for service in environment. Example: aemerror'
-  EnvironmentBlobStorageConfiguration:
+  DataStore:
     type: object
-    required:
-      - type
     properties:
       type:
         type: string
-        enum:
-          - azure_blob
-          - azure_files
-          - mongo_atlas
-    description: Settings for environment blob storage
-  EnvironmentLogStorageConfiguration:
-    type: object
-    required:
-      - type
-    properties:
-      type:
+      blobStorageAccountName:
         type: string
-        enum:
-          - azure_blob
-          - azure_files
-          - mongo_atlas
-    description: Settings for environment log storage
-  EnvironmentRegionintegrations:
-    type: object
-    properties:
-      blobStorage:
-        $ref: '#/definitions/EnvironmentBlobStorageConfiguration'
-      logStorage:
-        $ref: '#/definitions/EnvironmentLogStorageConfiguration'
-    description: integrations for a particular EnvironmentRegion
+      blobContainerName:
+        type: string
   RestorePointDetails:
     type: object
     properties:
@@ -7477,7 +6407,7 @@ definitions:
         type: object
         readOnly: true
         properties:
-          http://ns.adobe.com/adobecloud/rel/atlascluster:
+          'http://ns.adobe.com/adobecloud/rel/atlascluster':
             $ref: '#/definitions/HalLink'
   RestorePointsList:
     type: object
@@ -7552,11 +6482,11 @@ definitions:
       programId:
         type: string
         example: '14'
-        description: Identifier of the program, unique within the space
+        description: 'Identifier of the program, unique within the space'
       environmentId:
         type: string
         example: '14'
-        description: Identifier of the environment, unique within the space
+        description: 'Identifier of the environment, unique within the space'
       status:
         type: string
         example: not_started
@@ -7568,7 +6498,7 @@ definitions:
           - error
           - failed
       errorDetails:
-        description: Error details, present only when execution failed
+        description: 'Error details, present only when execution failed'
         $ref: '#/definitions/ErrorDetailsRepresentation'
       environmentDetailsAtSnapshotDate:
         description: Environment details at snapshot timestamp
@@ -7588,14 +6518,14 @@ definitions:
         type: object
         readOnly: true
         properties:
-          http://ns.adobe.com/adobecloud/rel/environment:
+          'http://ns.adobe.com/adobecloud/rel/environment':
             $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/flow:
+          'http://ns.adobe.com/adobecloud/rel/flow':
             $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/program:
+          'http://ns.adobe.com/adobecloud/rel/program':
             description: The Application this environment belongs to
             $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/restoreExecution/logs/download:
+          'http://ns.adobe.com/adobecloud/rel/restoreExecution/logs/download':
             $ref: '#/definitions/HalLink'
           self:
             $ref: '#/definitions/HalLink'
@@ -7665,62 +6595,54 @@ definitions:
       pointInTimeInMillis:
         type: string
         description: Desired point in time
-        pattern: \d{1,19}$
+        pattern: '\d{1,19}$'
   IPAllowedListBinding:
     type: object
     required:
       - environmentId
     properties:
       id:
-        type: string
-        example: '14'
-        description: Identifier of the IP Allowed List Binding to an Environment
+        type: integer
         format: int64
+        example: 14
+        description: Identifier of the IP Allowed List Binding to an Environment
       tier:
         type: string
         example: publish
         description: Tier of the environment.
         enum:
-          - author
-          - publish
-          - preview
-          - delivery
+          - PUBLISH
+          - PREVIEW
+          - AUTHOR
+          - STATIC
           - DELIVERY
       status:
         type: string
         example: NOT_STARTED
         description: Status of the binding.
-        enum:
-          - failed
-          - delete_failed
-          - running
-          - deleting
-          - completed
-          - deleted
-          - not_started
       programId:
-        type: string
-        example: '22'
+        type: integer
+        format: int64
+        example: 22
         description: Identifier of the program.
-        format: int64
       ipAllowListId:
-        type: string
-        example: '17'
+        type: integer
+        format: int64
+        example: 17
         description: Identifier of the IP allow list.
-        format: int64
       environmentId:
-        type: string
-        example: '5'
-        description: Identifier of the environment.
+        type: integer
         format: int64
+        example: 5
+        description: Identifier of the environment.
       _links:
         type: object
         readOnly: true
         properties:
-          http://ns.adobe.com/adobecloud/rel/program:
+          'http://ns.adobe.com/adobecloud/rel/program':
             description: The Application this environment belongs to.
             $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/ipAllowList:
+          'http://ns.adobe.com/adobecloud/rel/ipAllowList':
             description: IpAllowList to be binded to the environment.
             $ref: '#/definitions/HalLink'
           self:
@@ -7734,16 +6656,19 @@ definitions:
       - name
     properties:
       id:
-        type: string
-        example: '14'
-        description: Identifier of the IP Allowed List
+        type: integer
         format: int64
+        example: 14
+        description: Identifier of the IP Allowed List
       name:
         type: string
         example: NewYork Office
         description: Name of the IP Allowed List
-        minLength: 1
-        maxLength: 64
+      programId:
+        type: integer
+        format: int64
+        example: 22
+        description: Identifier of the program.
       ipCidrSet:
         type: array
         example: '["11.22.33.44/28", "99.88.77.66/32"]'
@@ -7753,11 +6678,6 @@ definitions:
           type: string
         maxItems: 50
         minItems: 1
-      programId:
-        type: string
-        example: '22'
-        description: Identifier of the program.
-        format: int64
       bindings:
         type: array
         description: IP Allowlist bindings
@@ -7767,15 +6687,34 @@ definitions:
         type: object
         readOnly: true
         properties:
-          http://ns.adobe.com/adobecloud/rel/ipAllowlistBindings:
+          'http://ns.adobe.com/adobecloud/rel/ipAllowlistBindings':
             $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/program:
+          'http://ns.adobe.com/adobecloud/rel/program':
             description: The Application this environment belongs to.
             $ref: '#/definitions/HalLink'
           self:
             $ref: '#/definitions/HalLink'
             description: This object's representation
     description: Describes an __IP Allowed List__
+  Updateanipallowlist:
+    type: object
+    required:
+      - ipCidrSet
+      - name
+    properties:
+      name:
+        type: string
+        example: NewYork Office
+        description: Name of the IP Allowed List
+      ipCidrSet:
+        type: array
+        example: '["11.22.33.44/28", "99.88.77.66/32"]'
+        description: IP CIDR Set
+        uniqueItems: true
+        items:
+          type: string
+        maxItems: 50
+        minItems: 1
   IPAllowlistBindingsList:
     type: object
     properties:
@@ -7783,6 +6722,8 @@ definitions:
         type: integer
         format: int32
         description: The total number of embedded items
+      ipAllowlistId:
+        type: string
       _embedded:
         type: object
         readOnly: true
@@ -7804,8 +6745,6 @@ definitions:
           self:
             $ref: '#/definitions/HalLink'
             description: This object's representation
-      ipAllowlistId:
-        type: string
   IPAllowlistList:
     type: object
     properties:
@@ -7834,1541 +6773,6 @@ definitions:
           self:
             $ref: '#/definitions/HalLink'
             description: This object's representation
-  DomainNameTargetRepresentation:
-    type: object
-    properties:
-      target:
-        type: string
-        description: IP or domain name which the domain name points to.
-      detected:
-        type: boolean
-        description: Flag that shows if the target was detected or not.
-        default: false
-  DomainName:
-    type: object
-    required:
-      - certificateId
-    properties:
-      id:
-        type: integer
-        format: int64
-        description: id
-      name:
-        type: string
-        example: customer.domain.com
-        description: Name of the domain name
-      status:
-        type: string
-        example: ready
-        description: Status of the domain name
-        enum:
-          - not_verified
-          - pending_deployment
-          - deployment_failed
-          - deployed
-          - pending_readiness_check
-          - ready
-          - deleting
-          - deleted
-          - delete_failed
-      type:
-        type: string
-        example: CNAME
-        description: Type of the domain name record
-        enum:
-          - A
-          - CNAME
-      dnsResolution:
-        type: array
-        description: Pointing IPs/domain name
-        items:
-          $ref: '#/definitions/DomainNameTargetRepresentation'
-      dnsTxtRecord:
-        type: string
-        example: adobe-aem-verification=www.adobe.com/1/2/ab-cd-ef
-        description: DNS TXT record
-      dnsZone:
-        type: string
-        example: adobe.com.
-        description: Name of the DNS zone
-      environmentId:
-        type: integer
-        format: int64
-        description: environmentId
-      environmentName:
-        type: string
-        example: customerEnvironmentName
-        description: Environment name
-      tier:
-        type: string
-        example: publish
-        description: Tier of the environment.
-        enum:
-          - publish
-          - preview
-      certificateId:
-        type: integer
-        format: int64
-        description: certificateId
-      certificateName:
-        type: string
-        example: My certificate
-        description: SSL Certificate name
-      certificateExpireAt:
-        type: string
-        format: date-time
-        description: SSL Certificate expiration date
-      createdAt:
-        type: string
-        format: date-time
-        description: Create date
-      updatedAt:
-        type: string
-        format: date-time
-        description: Update date
-      _links:
-        type: object
-        readOnly: true
-        properties:
-          http://ns.adobe.com/adobecloud/rel/domainName/certificates:
-            description: SSL certificates in program
-            $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/domainName/deploy:
-            description: Trigger DNS TXT record verification and start CDN deployment
-            $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/domainName/verify:
-            description: Trigger DNS route verification of the domain name
-            $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/environment:
-            description: The environment holding the domain name
-            $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/program:
-            description: The Application this domain name belongs to.
-            $ref: '#/definitions/HalLink'
-          self:
-            $ref: '#/definitions/HalLink'
-            description: This object's representation
-    description: A Domain Name representation
-  DomainNameList:
-    type: object
-    properties:
-      _totalNumberOfItems:
-        type: integer
-        format: int32
-        description: The total number of embedded items
-      _page:
-        $ref: '#/definitions/RequestedPageDetails'
-        description: Details of the requested page of items
-      _embedded:
-        type: object
-        readOnly: true
-        properties:
-          domainNames:
-            type: array
-            items:
-              $ref: '#/definitions/DomainName'
-      _links:
-        type: object
-        readOnly: true
-        properties:
-          next:
-            $ref: '#/definitions/HalLink'
-            description: The next page of results.
-          page:
-            $ref: '#/definitions/HalLink'
-            description: An arbitrary page of results.
-          prev:
-            $ref: '#/definitions/HalLink'
-            description: The previous page of results.
-          self:
-            $ref: '#/definitions/HalLink'
-            description: This object's representation
-  SslCertificate:
-    type: object
-    properties:
-      id:
-        type: string
-        description: id
-        format: int64
-      programId:
-        type: string
-        example: '14'
-        description: Identifier of the application. Unique within the space.
-        format: int64
-      serialNumber:
-        type: string
-        description: Unique identifier of the certificate at CA level.
-      name:
-        type: string
-        example: Certificate Name Example
-        description: Name of the SSL Certificate.
-      issuer:
-        type: string
-        description: Issuer of the SSL Certificate.
-      expireAt:
-        type: string
-        format: date-time
-        description: Expiration date of the SSL Certificate.
-      commonName:
-        type: string
-        description: Common name of the SSL Certificate.
-      subjectAlternativeNames:
-        type: array
-        description: Subject alternative names of the SSL Certificate.
-        items:
-          type: string
-      attachedDomainNames:
-        type: array
-        description: Attached domain names
-        items:
-          type: string
-      attachedEnvironmentNames:
-        type: array
-        description: Attached environment names
-        items:
-          type: string
-      createdAt:
-        type: string
-        format: date-time
-        description: Date of SSL Certificate submission.
-      updatedAt:
-        type: string
-        format: date-time
-        description: Date of last SSL Certificate update.
-      _links:
-        type: object
-        readOnly: true
-        properties:
-          self:
-            $ref: '#/definitions/HalLink'
-            description: This object's representation
-      sslCertificateType:
-        type: string
-        enum:
-          - DV
-          - EV
-          - OV
-      certificate:
-        type: string
-      privateKeyPath:
-        type: string
-      commonNameRegex:
-        type: string
-      subjectAlternativeNamesRegex:
-        type: array
-        items:
-          type: string
-      chain:
-        type: string
-      deletedAt:
-        type: integer
-        format: int64
-      externalId:
-        type: integer
-        format: int64
-      sslCertificateStatus:
-        type: string
-        enum:
-          - PENDING
-          - VALID
-          - EXPIRED
-    description: Describes an SSL Certificate
-  CertificatesList:
-    type: object
-    properties:
-      _totalNumberOfItems:
-        type: integer
-        format: int32
-        description: The total number of embedded items
-      _page:
-        $ref: '#/definitions/RequestedPageDetails'
-        description: Details of the requested page of items
-      _embedded:
-        type: object
-        readOnly: true
-        properties:
-          certificates:
-            type: array
-            items:
-              $ref: '#/definitions/SslCertificate'
-      _links:
-        type: object
-        readOnly: true
-        properties:
-          next:
-            $ref: '#/definitions/HalLink'
-            description: The next page of results.
-          page:
-            $ref: '#/definitions/HalLink'
-            description: An arbitrary page of results.
-          prev:
-            $ref: '#/definitions/HalLink'
-            description: The previous page of results.
-          self:
-            $ref: '#/definitions/HalLink'
-            description: This object's representation
-  NewRelicSub-AccountUser:
-    type: object
-    properties:
-      id:
-        type: string
-        example: '42'
-        description: Identifier of the New Relic sub account User
-      firstName:
-        type: string
-        example: John
-        description: First name of the New Relic sub account User
-      lastName:
-        type: string
-        example: Doe
-        description: Last name of the New Relic sub account User
-      email:
-        type: string
-        example: foobar@newrelic.com
-        description: email of the New Relic sub account user
-      role:
-        type: string
-        example: admin
-        description: Role of the New Relic sub account user
-      owner:
-        type: boolean
-        example: false
-        description: Owner detail of the New Relic sub account User
-        default: false
-    description: Describes __New Relic Sub-Account User__
-  NewRelicSubAccountUserlist:
-    type: object
-    properties:
-      _totalNumberOfNewRelicSubAccountUsers:
-        type: integer
-        format: int32
-      applicationId:
-        type: string
-        example: '44'
-        description: >-
-          The id of the Cloud Manager application this sub account user list is
-          linked to
-      _embedded:
-        type: object
-        readOnly: true
-        properties:
-          newRelicUsers:
-            type: array
-            items:
-              $ref: '#/definitions/NewRelicSub-AccountUser'
-      _links:
-        type: object
-        readOnly: true
-        properties:
-          http://ns.adobe.com/adobecloud/rel/application:
-            description: Application linked to this New Relic sub account
-            $ref: '#/definitions/HalLink'
-          http://ns.adobe.com/adobecloud/rel/newRelicSubAccount:
-            description: >-
-              New Relic sub account linked to the New Relic sub account User
-              list
-            $ref: '#/definitions/HalLink'
-          self:
-            $ref: '#/definitions/HalLink'
-            description: This object's representation
-    description: List of New Relic sub account users
-  Organisation:
-    type: object
-    properties:
-      organizationName:
-        type: string
-        example: adobecloudmanager-acmeCorp
-        description: Name of the git repository organization
-        minLength: 0
-        maxLength: 50
-      status:
-        type: string
-        example: creating
-        description: Status of the organisation on-boarding process
-        enum:
-          - not_started
-          - creating
-          - ready
-          - failed
-    description: Organisation details
-  Tenant:
-    type: object
-    required:
-      - imsOrgId
-      - imsTenantId
-    properties:
-      id:
-        type: string
-        example: '14'
-        description: Identifier of the tenant
-      imsOrgId:
-        type: string
-        example: 1AAA222B3C4444D55E666666@AdobeOrg
-        description: IMS Organization of this tenant
-        minLength: 0
-        maxLength: 255
-      imsTenantId:
-        type: string
-        example: acmeCorp
-        description: IMS Tenant Id
-        minLength: 0
-        maxLength: 255
-      description:
-        type: string
-        example: Description for acmeCorp
-        description: Description of the tenant
-        minLength: 0
-        maxLength: 255
-      status:
-        type: string
-        example: creating
-        description: Status of the tenant
-        enum:
-          - creating
-          - ready
-          - failed
-      organisation:
-        description: Tenant-level git repository organisation
-        $ref: '#/definitions/Organisation'
-      _links:
-        type: object
-        readOnly: true
-        properties:
-          http://ns.adobe.com/adobecloud/rel/programs:
-            description: Programs defined in the tenant
-            $ref: '#/definitions/HalLink'
-          self:
-            $ref: '#/definitions/HalLink'
-            description: This object's representation
-    description: Describes a __Tenant__
-  TenantList:
-    type: object
-    properties:
-      _totalNumberOfItems:
-        type: integer
-        format: int32
-        description: The total number of embedded items
-      _embedded:
-        type: object
-        readOnly: true
-        properties:
-          tenants:
-            type: array
-            items:
-              $ref: '#/definitions/Tenant'
-      _links:
-        type: object
-        readOnly: true
-        properties:
-          next:
-            $ref: '#/definitions/HalLink'
-            description: The next page of results.
-          prev:
-            $ref: '#/definitions/HalLink'
-            description: The previous page of results.
-          self:
-            $ref: '#/definitions/HalLink'
-            description: This object's representation
-  Region:
-    type: object
-    properties:
-      name:
-        type: string
-        example: va7
-        description: Region name
-      _links:
-        type: object
-        readOnly: true
-        properties:
-          self:
-            $ref: '#/definitions/HalLink'
-            description: This object's representation
-    description: Describes a __Region__
-  RegionsList:
-    type: object
-    properties:
-      _totalNumberOfItems:
-        type: integer
-        format: int32
-        description: The total number of embedded items
-      _embedded:
-        type: object
-        readOnly: true
-        properties:
-          regions:
-            type: array
-            items:
-              $ref: '#/definitions/Region'
-      _links:
-        type: object
-        readOnly: true
-        properties:
-          next:
-            $ref: '#/definitions/HalLink'
-            description: The next page of results.
-          prev:
-            $ref: '#/definitions/HalLink'
-            description: The previous page of results.
-          self:
-            $ref: '#/definitions/HalLink'
-            description: This object's representation
-  DnsConfiguration:
-    type: object
-    required:
-      - resolvers
-    properties:
-      resolvers:
-        type: array
-        description: List of remote DNS resolvers
-        items:
-          type: string
-    description: DNS Information. Only applicable to VPN infrastructures.
-  GatewayInfrastructure:
-    type: object
-    required:
-      - address
-      - addressSpace
-    properties:
-      address:
-        type: string
-        description: Customer VPN Device IP Address
-      addressSpace:
-        type: array
-        description: IP Ranges to route through the VPN
-        items:
-          type: string
-  IpSecPolicyInfrastructure:
-    type: object
-    required:
-      - dhGroup
-      - ikeEncryption
-      - ikeIntegrity
-      - ipsecEncryption
-      - ipsecIntegrity
-      - pfsGroup
-      - saDatasize
-      - saLifetime
-    properties:
-      dhGroup:
-        type: string
-        description: DH Group
-        enum:
-          - DHGroup24
-          - ECP384
-          - ECP256
-          - DHGroup14
-          - DHGroup2048
-          - DHGroup2
-          - DHGroup1
-          - None
-      ikeEncryption:
-        type: string
-        description: IKEv2 Encryption
-        enum:
-          - AES256
-          - AES192
-          - AES128
-          - DES3
-          - DES
-      ikeIntegrity:
-        type: string
-        description: IKEv2 Integrity
-        enum:
-          - SHA384
-          - SHA256
-          - SHA1
-          - MD5
-      ipsecEncryption:
-        type: string
-        description: IPsec Encryption
-        enum:
-          - GCMAES256
-          - GCMAES192
-          - GCMAES128
-          - AES256
-          - AES192
-          - AES128
-          - DES3
-          - DES
-          - None
-      ipsecIntegrity:
-        type: string
-        description: IPsec Integrity
-        enum:
-          - GCMAES256
-          - GCMAES192
-          - GCMAES128
-          - SHA256
-          - SHA1
-          - MD5
-      pfsGroup:
-        type: string
-        description: PFS Group
-        enum:
-          - PFS24
-          - ECP384
-          - ECP256
-          - PFS2048
-          - PFS2
-          - PFS1
-          - None
-      saDatasize:
-        type: integer
-        format: int64
-        description: QM SA Lifetime in KBytes under 1024
-        minimum: 1024
-      saLifetime:
-        type: integer
-        format: int32
-        description: QM SA Lifetime in Seconds, minimum 300
-        minimum: 300
-  VpnConnection:
-    type: object
-    required:
-      - gateway
-      - ipsecPolicy
-      - name
-      - sharedKey
-    properties:
-      name:
-        type: string
-        description: Name of the connection
-      gateway:
-        description: Gateway configuration
-        $ref: '#/definitions/GatewayInfrastructure'
-      sharedKey:
-        type: string
-        description: Customer VPN preshared key
-      ipsecPolicy:
-        description: IPSec Policy
-        $ref: '#/definitions/IpSecPolicyInfrastructure'
-  NetworkInfrastructure:
-    type: object
-    required:
-      - kind
-      - region
-    properties:
-      kind:
-        type: string
-        description: Kind of the infrastructure
-        enum:
-          - vpn
-          - dedicatedEgressIp
-          - flexiblePortEgress
-      id:
-        type: string
-        description: id
-        readOnly: true
-      programId:
-        type: string
-        example: '14'
-        description: Identifier of the program. Unique within the space.
-        readOnly: true
-      status:
-        type: string
-        example: creating
-        description: Status of the network configuration
-        enum:
-          - creating
-          - failed
-          - updating
-          - deleting
-          - deleted
-          - ready
-          - error
-        readOnly: true
-      region:
-        type: string
-        example: va6
-        description: >-
-          Region to create the infrastructure. Use your primary region, whose
-          identifier can be retrieved from the [List Regions
-          endpoint](#operation/getProgramRegions).
-      isPrimaryRegion:
-        type: boolean
-        description: >-
-          Boolean property to mark whether network infrastructure being created
-          is for primary region or not.
-        default: false
-      created:
-        type: string
-        format: date-time
-        description: Creation date
-        readOnly: true
-      updated:
-        type: string
-        format: date-time
-        description: Last modification date
-        readOnly: true
-      addressSpace:
-        type: array
-        description: >-
-          A list of CIDRs. It can only be one /26 CIDR (64 IP addresses) or
-          bigger IP range in the customer space. Cannot be changed later. Only
-          applicable to VPN.
-        items:
-          type: string
-      dns:
-        description: DNS Information. Only applicable to VPN infrastructures.
-        $ref: '#/definitions/DnsConfiguration'
-      connections:
-        type: array
-        description: List of VPN connections
-        items:
-          $ref: '#/definitions/VpnConnection'
-      statusDetails:
-        description: Error details. Present only when failed operations.
-        $ref: '#/definitions/ErrorDetailsRepresentation'
-        readOnly: true
-      _links:
-        type: object
-        readOnly: true
-        properties:
-          http://ns.adobe.com/adobecloud/rel/program:
-            $ref: '#/definitions/HalLink'
-          self:
-            $ref: '#/definitions/HalLink'
-            description: This object's representation
-    description: An network infrastructure representation
-  NetworkInfrastructuresList:
-    type: object
-    properties:
-      _totalNumberOfItems:
-        type: integer
-        format: int32
-        description: The total number of embedded items
-      _embedded:
-        type: object
-        readOnly: true
-        properties:
-          networkInfrastructures:
-            type: array
-            items:
-              $ref: '#/definitions/NetworkInfrastructure'
-      _links:
-        type: object
-        readOnly: true
-        properties:
-          next:
-            $ref: '#/definitions/HalLink'
-            description: The next page of results.
-          prev:
-            $ref: '#/definitions/HalLink'
-            description: The previous page of results.
-          self:
-            $ref: '#/definitions/HalLink'
-            description: This object's representation
-  PortForwardRepresentation:
-    type: object
-    required:
-      - portDest
-      - portOrig
-    properties:
-      name:
-        type: string
-        example: smtp.example.com
-        description: Destination host
-        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?([.][a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-      portDest:
-        type: integer
-        format: int32
-        example: 443
-        description: Destination port
-        maximum: 65535
-      portOrig:
-        type: integer
-        format: int32
-        example: 30710
-        description: Origin port for tunnel. Must be unique and in 30000-31000 range.
-        minimum: 30000
-        maximum: 31000
-  AdvancedNetworkingConfiguration:
-    type: object
-    properties:
-      programId:
-        type: string
-        example: '14'
-        description: Identifier of the program. Unique within the space.
-        readOnly: true
-      environmentId:
-        type: string
-        description: Identifier of the environment. Unique within the space.
-        readOnly: true
-      networkInfrastructureId:
-        type: string
-        example: '123'
-        description: Advanced network infrastructure used.
-        readOnly: true
-      nonProxyHosts:
-        type: array
-        description: >-
-          A list of hosts that should be reached directly, bypassing the special
-          VPN or egress routing. The patterns may start or end with a ''*'' for
-          wildcards.
-        items:
-          type: string
-        example:
-          - '*.example.com'
-          - '*.example.net'
-      portForwards:
-        type: array
-        description: List of port forwarding rules
-        items:
-          $ref: '#/definitions/PortForwardRepresentation'
-      advancedNetworkingEnabled:
-        type: boolean
-        description: Whether advanced networking is enabled in this environment
-        default: false
-        readOnly: true
-      _links:
-        type: object
-        readOnly: true
-        properties:
-          self:
-            $ref: '#/definitions/HalLink'
-            description: This object's representation
-    description: Describes the Advanced Networking configuration for an environment
-  AdvancedNetworkingConfigurationList:
-    type: object
-    properties:
-      _totalNumberOfItems:
-        type: integer
-        format: int32
-        description: The total number of embedded items
-      _embedded:
-        type: object
-        readOnly: true
-        properties:
-          networkingConfigurations:
-            type: array
-            items:
-              $ref: '#/definitions/AdvancedNetworkingConfiguration'
-      _links:
-        type: object
-        readOnly: true
-        properties:
-          next:
-            $ref: '#/definitions/HalLink'
-            description: The next page of results.
-          prev:
-            $ref: '#/definitions/HalLink'
-            description: The previous page of results.
-          self:
-            $ref: '#/definitions/HalLink'
-            description: This object's representation
-  ContentFlowValidationErrors:
-    type: object
-    properties:
-      errorCode:
-        type: string
-        description: content flow warning error code
-      message:
-        type: string
-        description: content flow warning message
-      details:
-        type: array
-        description: details
-        items:
-          type: string
-    description: The Content Flow Validation Errors
-  ContentFlowInfo:
-    type: object
-    properties:
-      validationErrors:
-        type: array
-        description: validationErrors
-        items:
-          $ref: '#/definitions/ContentFlowValidationErrors'
-    description: The Content Flow Info
-  ContentFlowResultDetails:
-    type: object
-    properties:
-      errorCode:
-        type: string
-        description: content flow error
-      message:
-        type: string
-        description: content flow error message
-      details:
-        type: array
-        description: details
-        items:
-          type: string
-      info:
-        description: info
-        $ref: '#/definitions/ContentFlowInfo'
-      phase:
-        type: string
-        description: phase
-    description: The Content Flow Result Details
-  ContentFlowInput:
-    type: object
-    properties:
-      contentSetId:
-        type: string
-      destEnvironmentId:
-        type: string
-      tier:
-        type: string
-        example: author
-        description: tier
-      includeACL:
-        type: boolean
-        description: includeACL
-        default: false
-      destProgramId:
-        type: string
-        description: destProgramId
-      mergeExcludePaths:
-        type: boolean
-        description: mergeExcludePaths
-        default: false
-      copyVersions:
-        type: boolean
-        description: copyVersions
-        default: false
-    description: Wraps the content flow execution arguments
-  CompatibilityCheckInput:
-    type: object
-    required:
-      - destinationEnvironmentId
-      - sourceEnvironmentId
-    properties:
-      sourceEnvironmentId:
-        type: string
-      destinationEnvironmentId:
-        type: string
-      tier:
-        type: string
-        enum:
-          - PUBLISH
-          - AUTHOR
-    description: Wraps the content copy compatibility check execution arguments.
-  CompatibilityCheckResponse:
-    type: object
-    properties:
-      sourceEnvironmentId:
-        type: string
-        example: '1234'
-        description: The source environment ID
-      sourceTopologyId:
-        type: string
-        example: 1a2b3cd4
-        description: The source topology ID
-      destinationEnvironmentId:
-        type: string
-        example: '5678'
-        description: The destination environment ID
-      destinationTopologyId:
-        type: string
-        example: 1a2b3cd4
-        description: The destination topology ID
-      tier:
-        type: string
-        example: author
-        description: tier
-      overallResult:
-        type: string
-        example: PASS
-        description: The overall result of the compatibility check
-      overallMessage:
-        type: string
-        example: Destination Topology cannot be prod.
-        description: The overall response message of the compatibility check
-      failedValidation:
-        type: string
-        example: TIER_NOT_ALLOWED
-        description: Error Code for the Failed Compatibility Check
-        enum:
-          - SOURCE_DISK_ORG
-          - TARGET_DISK_ORG
-          - SOURCE_REPO_TYPE
-          - TARGET_REPO_TYPE
-          - DATASTORE_TYPE
-          - BLOCK_TYPE
-          - TARGET_ENV
-          - REGION_CRITERIA
-          - CONNECTION_ERROR
-          - UNSUPPORTED_SKYLINE_ENV
-          - BAD_REQUEST
-          - ENVIRONMENT_NOT_FOUND
-          - PROGRAM_NOT_FOUND
-          - TIER_NOT_ALLOWED
-          - UNKNOWN
-      responseStatusCode:
-        type: integer
-        format: int32
-    description: Describes the Backflow Compatibility between two topologies.
-  ContentFlowLog:
-    type: object
-    properties:
-      jobType:
-        type: string
-        example: (import or export)
-        description: job type
-      programId:
-        type: integer
-        format: int64
-      contentFlowId:
-        type: integer
-        format: int64
-      _links:
-        type: object
-        readOnly: true
-        properties:
-          download:
-            description: Download Logs link
-            $ref: '#/definitions/HalLink'
-          logs/tail:
-            description: Tail Log link
-            $ref: '#/definitions/HalLink'
-    description: Log from Content Flow
-  Redirect:
-    type: object
-    required:
-      - redirect
-    properties:
-      redirect:
-        type: string
-        description: The url to redirect to.
-  NewSslCertificate:
-    type: object
-    required:
-      - name
-      - certificate
-      - privateKey
-      - chain
-    properties:
-      name:
-        type: string
-        description: The name of the new SSL Certificate.
-      certifcate:
-        type: string
-        description: The PEM-encoded certificate.
-      privateKey:
-        type: string
-        description: The PEM-encoded private key.
-      chain:
-        type: array
-        items:
-          type: string
-        description: The PEM-encoded certificate chain.
-  NewFeedback:
-    type: object
-    required:
-      - rating
-      - type
-    properties:
-      createdAt:
-        type: string
-        description: Created time
-      id:
-        type: integer
-        description: Identifier of the feedback. Unique within the space.
-      rating:
-        type: integer
-        description: Rating values from 1 to 5
-      comment:
-        type: string
-        description: Feedback comment
-      type:
-        type: string
-        description: Type of feedback
-        enum:
-          - GO_LIVE
-      options:
-        type: object
-        description: Optional information about the feedback
-    description: Describes feedback
-  GoLiveDates:
-    type: object
-    properties:
-      plannedDate:
-        type: string
-        description: Date when go live is planned
-      actualDate:
-        type: string
-        description: Date when the program completed go live
-    description: Contains planned and actual go live dates of a program
-  PipelineUpdate:
-    type: object
-    description: Describe an update to a pipeline
-    properties:
-      phases:
-        type: array
-        description: Pipeline phases to update
-        items:
-          $ref: '#/definitions/PipelinePhaseUpdate'
-  EnvironmentVariableUpdate:
-    type: object
-    properties:
-      name:
-        type: string
-        example: MY_VAR1
-        description: >-
-          Name of the variable. Can only consist of a-z, A-Z, _ and 0-9 and
-          cannot begin with a number.
-        minLength: 2
-        maxLength: 100
-        pattern: '[a-zA-Z_][a-zA-Z_0-9]*'
-      value:
-        type: string
-        example: myValue
-        description: >-
-          Value of the variable. Read-Write for non-secrets, write-only for
-          secrets. The length of `secretString` values must be less than 500
-          characters. An empty value causes a variable to be deleted.
-        minLength: 0
-        maxLength: 2048
-      type:
-        type: string
-        example: string
-        description: >-
-          Type of the variable. Default `string` if missing. `secretString`
-          variables are encrypted at rest. The type of a variable be changed
-          after creation; the variable must be deleted and recreated.
-        enum:
-          - string
-          - secretString
-      service:
-        type: string
-        example: author
-        description: >-
-          Service of the variable. When not provided, the variable applies to
-          all services. Currently the values 'author', 'publish', and 'preview'
-          are supported. Note - this value is case-sensitive.
-    description: A change (create, update, delete) of a named value on an Environment
-  PipelineVariableUpdate:
-    type: object
-    properties:
-      name:
-        type: string
-        example: MY_VAR1
-        description: >-
-          Name of the variable. Can only consist of a-z, A-Z, _ and 0-9 and
-          cannot begin with a number.
-        minLength: 2
-        maxLength: 100
-        pattern: '[a-zA-Z_][a-zA-Z_0-9]*'
-      value:
-        type: string
-        example: myValue
-        description: >-
-          Value of the variable. Read-Write for non-secrets, write-only for
-          secrets. The length of `secretString` values must be less than 500
-          characters. An empty value causes a variable to be deleted.
-        minLength: 0
-        maxLength: 2048
-      type:
-        type: string
-        example: string
-        description: >-
-          Type of the variable. Default `string` if missing. `secretString`
-          variables are encrypted at rest. The type of a variable be changed
-          after creation; the variable must be deleted and recreated.
-        enum:
-          - string
-          - secretString
-    description: A change (create, update, delete) of a named value on a Pipeline
-  PipelinePhaseUpdate:
-    type: object
-    required:
-      - type
-    description: Describes an update to a phase of a pipeline
-    properties:
-      name:
-        type: string
-        example: BUILD_1
-        description: Name of the phase
-      type:
-        type: string
-        example: BUILD
-        description: Type of the phase
-        enum:
-          - BUILD
-          - DEPLOY
-      repositoryId:
-        type: string
-        description: >-
-          For BUILD phase type. Identifier of the source repository. The code
-          from this repository will be build at the start of this phase. If not
-          provided, the current value is retained.
-      branch:
-        type: string
-        description: >-
-          For BUILD phase type. Name of the tracked branch or a fully qualified
-          git tag (e.g. refs/tags/v1). If not provided, the current value is
-          retained.
-      environmentId:
-        type: string
-        description: For DEPLOY phase type. Identifier of the target environment.
-      steps:
-        type: array
-        description: Steps to update within the phase.
-        items:
-          $ref: '#/definitions/PipelineStepUpdate'
-  PipelineStepUpdate:
-    type: object
-    required:
-      - type
-    description: Describes an update to a phase of a pipeline
-    properties:
-      name:
-        type: string
-        example: deploy
-        description: Name of the step
-      options:
-        type: object
-        description: Map of option parameters for the step
-        $ref: '#/definitions/PipelineStepUpdateOptions'
-  PipelineStepUpdateOptions:
-    type: object
-    properties:
-      dispatcherCacheInvalidationPaths:
-        type: array
-        items:
-          type: string
-        description: >-
-          For deploy steps on AMS pipelines, list of paths to invalidate on
-          dispatchers after package installation.
-      dispatcherCacheFlushPaths:
-        type: array
-        items:
-          type: string
-        description: >-
-          For deploy steps on AMS pipelines, list of paths to flush on
-          dispatchers after package installation.
-  EnableAdvancedNetworkingConfiguration:
-    type: object
-    properties:
-      nonProxyHosts:
-        type: array
-        description: >-
-          A list of hosts that should be reached directly, bypassing the special
-          VPN or egress routing. The patterns may start or end with a ''*'' for
-          wildcards.
-        items:
-          type: string
-        example:
-          - '*.example.com'
-          - '*.example.net'
-      portForwards:
-        type: array
-        description: List of port forwarding rules
-        items:
-          $ref: '#/definitions/PortForwardRepresentation'
-  PipelineExecutionStepStateDetails:
-    type: object
-    description: >-
-      Details available for each step state. The set of properties available
-      will vary by the step action.
-    properties:
-      deployCommands:
-        type: string
-        description: >-
-          For deploy steps, a JSON array encoded as a string which lists the
-          deployment activities expected to be performed.
-      currentDeployCommandId:
-        type: string
-        description: >-
-          For deploy steps, the current identifier from the deployCommands which
-          is being executed.
-      environmentUrls:
-        type: array
-        description: For deploy steps, the the set of URLs for the environment.
-        items:
-          type: object
-          properties:
-            instanceType:
-              type: string
-            instanceUrl:
-              type: string
-      deploymentStepDescription:
-        type: string
-        description: >-
-          For deploy steps, a JSON array encoded as a string which includes the
-          detailed list of deployment activities which have been performed.
-      input:
-        type: object
-        description: >-
-          Input provided when advancing the step. See documentation at
-          https://www.adobe.io/experience-cloud/cloud-manager/guides/api-usage/advancing-and-cancelling-steps/
-          for details.
-  PipelineStepOptions:
-    type: object
-    description: Options for a pipeline step. Will vary based on step action and platform.
-    properties:
-      skipDetachingDispatchers:
-        type: boolean
-        description: >-
-          For deploy steps on AMS pipelines, if true will not detach dispatcher
-          from the load balancer.
-      dispatcherCacheInvalidationPaths:
-        type: array
-        items:
-          type: string
-        description: >-
-          For deploy steps on AMS pipelines, list of paths to invalidate on
-          dispatchers after package installation.
-      dispatcherCacheFlushPaths:
-        type: array
-        items:
-          type: string
-        description: >-
-          For deploy steps on AMS pipelines, list of paths to flush on
-          dispatchers after package installation.
-      cse:
-        type: string
-        enum:
-          - MY_CSE
-          - ANY_CSE
-        description: >-
-          For managed steps on AMS pipelines, which CSE will be responsible for
-          CSE oversight.
-      popularPagesWeight:
-        type: integer
-        format: int32
-        description: >-
-          For loadTest steps on AMS pipelines, the percentage of performance
-          test traffic which will be sent to the popular pages bucket.
-      newPagesWeight:
-        type: integer
-        format: int32
-        description: >-
-          For loadTest steps on AMS pipelines, the percentage of performance
-          test traffic which will be sent to the new pages bucket.
-      otherPagesWeight:
-        type: integer
-        format: int32
-        description: >-
-          For loadTest steps on AMS pipelines, the percentage of performance
-          test traffic which will be sent to the other pages bucket.
-      imageAssetsWeight:
-        type: integer
-        format: int32
-        description: >-
-          For assetsTest steps on AMS pipelines, the percentage of asset uploads
-          which will be test images.
-      pdfAssetsWeight:
-        type: integer
-        format: int32
-        description: >-
-          For assetsTest steps on AMS pipelines, the percentage of asset uploads
-          which will be test PDF files.
-  NewProgram:
-    type: object
-    required:
-      - name
-      - type
-    description: Description of a new program to be created
-    properties:
-      name:
-        type: string
-        description: New program name
-        minLength: 0
-        maxLength: 64
-      type:
-        type: string
-        enum:
-          - aem_cloud_service
-      capabilities:
-        $ref: '#/definitions/ProgramCapabilities'
-      solutionNames:
-        type: array
-        description: List of solutions to be enabled on the new program.
-        items:
-          type: string
-          enum:
-            - aemsites
-            - aemassets
-      goLive:
-        description: Go live dates
-        $ref: '#/definitions/GoLiveDates'
-  NewEnvironment:
-    type: object
-    description: Description of a new program to be created
-    required:
-      - name
-      - region
-      - type
-    properties:
-      name:
-        type: string
-        example: acme-dev1
-        description: Name of the environment
-      type:
-        type: string
-        enum:
-          - dev
-          - stage
-          - prod
-          - rde
-      region:
-        type: string
-        example: va7
-        description: Region to create the environment.
-      description:
-        type: string
-        example: This is our primary development environment
-        description: Description of the environment
-  NewRegionDeployment:
-    type: object
-    description: Description of a new region deployment to be added in the environment
-    required:
-      - region
-    properties:
-      region:
-        type: string
-        example: va7
-        description: Region to be added in the environment
-  RegionDeploymentDeletion:
-    type: object
-    description: Description of region deployment to be deleted in the environment
-    required:
-      - id
-      - status
-    properties:
-      id:
-        type: string
-        description: Identifier of the  region deployment
-      status:
-        type: string
-        example: TO_DELETE
-        description: Status of the region deployment to be set
-  DomainNameValidate:
-    type: object
-    description: Description of a domain name to validate
-    required:
-      - name
-      - environmentId
-      - certificateId
-    properties:
-      name:
-        type: string
-        example: customer.domain.com
-        description: Name of the domain name
-      environmentId:
-        type: integer
-        format: int64
-        description: The environment id
-      certificateId:
-        type: integer
-        format: int64
-        description: The certificate id
-  NewDomainName:
-    type: object
-    description: Description of a domain name to create
-    required:
-      - name
-      - environmentId
-      - certificateId
-      - dnsTxtRecord
-      - dnsZone
-    properties:
-      name:
-        type: string
-        example: customer.domain.com
-        description: Name of the domain name
-      environmentId:
-        type: integer
-        format: int64
-        description: The environment id
-      certificateId:
-        type: integer
-        format: int64
-        description: The certificate id
-      dnsTxtRecord:
-        type: string
-        example: adobe-aem-verification=www.adobe.com/1/2/ab-cd-ef
-        description: >-
-          DNS TXT record. Must match the corresponding record returned from the
-          validate request.
-      dnsZone:
-        type: string
-        example: adobe.com.
-        description: >-
-          Name of the DNS zone. Must match the corresponding value returned from
-          the validate request.
-  NewRelicSubAccountUser:
-    type: object
-    properties:
-      id:
-        type: string
-        example: '42'
-        description: Identifier of the New Relic sub account User
-      firstName:
-        type: string
-        example: John
-        description: First name of the New Relic sub account User
-      lastName:
-        type: string
-        example: Doe
-        description: Last name of the New Relic sub account User
-      email:
-        type: string
-        example: foobar@newrelic.com
-        description: email of the New Relic sub account user
-      role:
-        type: string
-        example: admin
-        description: Role of the New Relic sub account user
-      owner:
-        type: boolean
-        example: false
-        description: Owner detail of the New Relic sub account User
-        default: false
-    description: Describes __New Relic Sub-Account User__
-  NewContentSet:
-    type: object
-    properties:
-      name:
-        type: string
-        description: The name of this content set.
-      description:
-        type: string
-        description: The description of this content set.
-      paths:
-        type: array
-        description: Included asset paths
-        items:
-          $ref: '#/definitions/ContentSetPath'
-  ContentFlowLogs:
-    type: object
-    properties:
-      download:
-        $ref: '#/definitions/Redirect'
-        description: link to download logs
-      logs/tail:
-        $ref: '#/definitions/Redirect'
-        description: link to download tails log
-  DataStore:
-    type: object
-    properties:
-      type:
-        type: string
-      blobStorageAccountName:
-        type: string
-      blobContainerName:
-        type: string
-  Updateanipallowlist:
-    type: object
-    required:
-      - ipCidrSet
-      - name
-    properties:
-      name:
-        type: string
-        example: NewYork Office
-        description: Name of the IP Allowed List
-      ipCidrSet:
-        type: array
-        example: '["11.22.33.44/28", "99.88.77.66/32"]'
-        description: IP CIDR Set
-        uniqueItems: true
-        items:
-          type: string
-        maxItems: 50
-        minItems: 1
   Createanewipallowlist:
     type: object
     required:
@@ -9691,9 +7095,7 @@ definitions:
       value:
         type: string
         example: my-secret
-        description: >-
-          Secret value for updating the secrets, null for not updating the
-          existing secret
+        description: 'Secret value for updating the secrets, null for not updating the existing secret'
       path:
         type: string
         example: /path/to/secret
@@ -9769,6 +7171,66 @@ definitions:
         items:
           type: integer
           format: int64
+  SslCertificate:
+    type: object
+    properties:
+      id:
+        type: integer
+        format: int64
+      sslCertificateType:
+        type: string
+        enum:
+          - DV
+          - EV
+          - OV
+      programId:
+        type: integer
+        format: int64
+      serialNumber:
+        type: string
+      name:
+        type: string
+      certificate:
+        type: string
+      issuer:
+        type: string
+      expireAt:
+        type: integer
+        format: int64
+      privateKeyPath:
+        type: string
+      commonName:
+        type: string
+      commonNameRegex:
+        type: string
+      subjectAlternativeNames:
+        type: array
+        items:
+          type: string
+      subjectAlternativeNamesRegex:
+        type: array
+        items:
+          type: string
+      chain:
+        type: string
+      createdAt:
+        type: integer
+        format: int64
+      updatedAt:
+        type: integer
+        format: int64
+      deletedAt:
+        type: integer
+        format: int64
+      externalId:
+        type: integer
+        format: int64
+      sslCertificateStatus:
+        type: string
+        enum:
+          - PENDING
+          - VALID
+          - EXPIRED
   Site:
     type: object
     properties:
@@ -9839,3 +7301,1075 @@ definitions:
           self:
             $ref: '#/definitions/HalLink'
             description: This object's representation
+  NewRelicSub-AccountUser:
+    type: object
+    properties:
+      id:
+        type: string
+        example: '42'
+        description: Identifier of the New Relic sub account User
+      firstName:
+        type: string
+        example: John
+        description: First name of the New Relic sub account User
+      lastName:
+        type: string
+        example: Doe
+        description: Last name of the New Relic sub account User
+      email:
+        type: string
+        example: foobar@newrelic.com
+        description: email of the New Relic sub account user
+      role:
+        type: string
+        example: admin
+        description: Role of the New Relic sub account user
+      owner:
+        type: boolean
+        example: false
+        description: Owner detail of the New Relic sub account User
+        default: false
+    description: Describes __New Relic Sub-Account User__
+  NewRelicSubAccountUserlist:
+    type: object
+    properties:
+      _totalNumberOfNewRelicSubAccountUsers:
+        type: integer
+        format: int32
+      applicationId:
+        type: string
+        example: '44'
+        description: The id of the Cloud Manager application this sub account user list is linked to
+      _embedded:
+        type: object
+        readOnly: true
+        properties:
+          newRelicUsers:
+            type: array
+            items:
+              $ref: '#/definitions/NewRelicSub-AccountUser'
+      _links:
+        type: object
+        readOnly: true
+        properties:
+          'http://ns.adobe.com/adobecloud/rel/application':
+            description: Application linked to this New Relic sub account
+            $ref: '#/definitions/HalLink'
+          'http://ns.adobe.com/adobecloud/rel/newRelicSubAccount':
+            description: New Relic sub account linked to the New Relic sub account User list
+            $ref: '#/definitions/HalLink'
+          self:
+            $ref: '#/definitions/HalLink'
+            description: This object's representation
+    description: List of New Relic sub account users
+  Organisation:
+    type: object
+    properties:
+      organizationName:
+        type: string
+        example: adobecloudmanager-acmeCorp
+        description: Name of the git repository organization
+        minLength: 0
+        maxLength: 50
+      status:
+        type: string
+        example: creating
+        description: Status of the organisation on-boarding process
+        enum:
+          - not_started
+          - creating
+          - ready
+          - failed
+    description: Organisation details
+  Tenant:
+    type: object
+    required:
+      - imsOrgId
+      - imsTenantId
+    properties:
+      id:
+        type: string
+        example: '14'
+        description: Identifier of the tenant
+      imsOrgId:
+        type: string
+        example: 1AAA222B3C4444D55E666666@AdobeOrg
+        description: IMS Organization of this tenant
+        minLength: 0
+        maxLength: 255
+      imsTenantId:
+        type: string
+        example: acmeCorp
+        description: IMS Tenant Id
+        minLength: 0
+        maxLength: 255
+      description:
+        type: string
+        example: Description for acmeCorp
+        description: Description of the tenant
+        minLength: 0
+        maxLength: 255
+      status:
+        type: string
+        example: creating
+        description: Status of the tenant
+        enum:
+          - creating
+          - ready
+          - failed
+      organisation:
+        description: Tenant-level git repository organisation
+        $ref: '#/definitions/Organisation'
+      _links:
+        type: object
+        readOnly: true
+        properties:
+          'http://ns.adobe.com/adobecloud/rel/programs':
+            description: Programs defined in the tenant
+            $ref: '#/definitions/HalLink'
+          self:
+            $ref: '#/definitions/HalLink'
+            description: This object's representation
+    description: Describes a __Tenant__
+  TenantList:
+    type: object
+    properties:
+      _totalNumberOfItems:
+        type: integer
+        format: int32
+        description: The total number of embedded items
+      _embedded:
+        type: object
+        readOnly: true
+        properties:
+          tenants:
+            type: array
+            items:
+              $ref: '#/definitions/Tenant'
+      _links:
+        type: object
+        readOnly: true
+        properties:
+          next:
+            $ref: '#/definitions/HalLink'
+            description: The next page of results.
+          prev:
+            $ref: '#/definitions/HalLink'
+            description: The previous page of results.
+          self:
+            $ref: '#/definitions/HalLink'
+            description: This object's representation
+  Region:
+    type: object
+    properties:
+      name:
+        type: string
+        example: va7
+        description: Region name
+      _links:
+        type: object
+        readOnly: true
+        properties:
+          self:
+            $ref: '#/definitions/HalLink'
+            description: This object's representation
+    description: Describes a __Region__
+  RegionsList:
+    type: object
+    properties:
+      _totalNumberOfItems:
+        type: integer
+        format: int32
+        description: The total number of embedded items
+      _embedded:
+        type: object
+        readOnly: true
+        properties:
+          regions:
+            type: array
+            items:
+              $ref: '#/definitions/Region'
+      _links:
+        type: object
+        readOnly: true
+        properties:
+          next:
+            $ref: '#/definitions/HalLink'
+            description: The next page of results.
+          prev:
+            $ref: '#/definitions/HalLink'
+            description: The previous page of results.
+          self:
+            $ref: '#/definitions/HalLink'
+            description: This object's representation
+  DnsConfiguration:
+    type: object
+    required:
+      - resolvers
+    properties:
+      resolvers:
+        type: array
+        description: List of remote DNS resolvers
+        items:
+          type: string
+    description: DNS Information. Only applicable to VPN infrastructures.
+  GatewayInfrastructure:
+    type: object
+    required:
+      - address
+      - addressSpace
+    properties:
+      address:
+        type: string
+        description: Customer VPN Device IP Address
+      addressSpace:
+        type: array
+        description: IP Ranges to route through the VPN
+        items:
+          type: string
+  IpSecPolicyInfrastructure:
+    type: object
+    required:
+      - dhGroup
+      - ikeEncryption
+      - ikeIntegrity
+      - ipsecEncryption
+      - ipsecIntegrity
+      - pfsGroup
+      - saDatasize
+      - saLifetime
+    properties:
+      dhGroup:
+        type: string
+        description: DH Group
+        enum:
+          - DHGroup24
+          - ECP384
+          - ECP256
+          - DHGroup14
+          - DHGroup2048
+          - DHGroup2
+          - DHGroup1
+          - None
+      ikeEncryption:
+        type: string
+        description: IKEv2 Encryption
+        enum:
+          - AES256
+          - AES192
+          - AES128
+          - DES3
+          - DES
+      ikeIntegrity:
+        type: string
+        description: IKEv2 Integrity
+        enum:
+          - SHA384
+          - SHA256
+          - SHA1
+          - MD5
+      ipsecEncryption:
+        type: string
+        description: IPsec Encryption
+        enum:
+          - GCMAES256
+          - GCMAES192
+          - GCMAES128
+          - AES256
+          - AES192
+          - AES128
+          - DES3
+          - DES
+          - None
+      ipsecIntegrity:
+        type: string
+        description: IPsec Integrity
+        enum:
+          - GCMAES256
+          - GCMAES192
+          - GCMAES128
+          - SHA256
+          - SHA1
+          - MD5
+      pfsGroup:
+        type: string
+        description: PFS Group
+        enum:
+          - PFS24
+          - ECP384
+          - ECP256
+          - PFS2048
+          - PFS2
+          - PFS1
+          - None
+      saDatasize:
+        type: integer
+        format: int64
+        description: QM SA Lifetime in KBytes under 1024
+        minimum: 1024
+      saLifetime:
+        type: integer
+        format: int32
+        description: 'QM SA Lifetime in Seconds, minimum 300'
+        minimum: 300
+  VpnConnection:
+    type: object
+    required:
+      - gateway
+      - ipsecPolicy
+      - name
+      - sharedKey
+    properties:
+      name:
+        type: string
+        description: Name of the connection
+      gateway:
+        description: Gateway configuration
+        $ref: '#/definitions/GatewayInfrastructure'
+      sharedKey:
+        type: string
+        description: Customer VPN preshared key
+      ipsecPolicy:
+        description: IPSec Policy
+        $ref: '#/definitions/IpSecPolicyInfrastructure'
+  NetworkInfrastructure:
+    type: object
+    required:
+      - kind
+      - region
+    properties:
+      kind:
+        type: string
+        description: Kind of the infrastructure
+        enum:
+          - vpn
+          - dedicatedEgressIp
+          - flexiblePortEgress
+      id:
+        type: string
+        description: id
+        readOnly: true
+      programId:
+        type: string
+        example: '14'
+        description: Identifier of the program. Unique within the space.
+        readOnly: true
+      status:
+        type: string
+        example: creating
+        description: Status of the network configuration
+        enum:
+          - creating
+          - failed
+          - updating
+          - deleting
+          - deleted
+          - ready
+          - error
+        readOnly: true
+      region:
+        type: string
+        example: va6
+        description: 'Region to create the infrastructure. Use your primary region, whose identifier can be retrieved from the [List Regions endpoint](#operation/getProgramRegions).'
+      isPrimaryRegion:
+        type: boolean
+        description: Boolean property to mark whether network infrastructure being created is for primary region or not.
+        default: false
+      created:
+        type: string
+        format: date-time
+        description: Creation date
+        readOnly: true
+      updated:
+        type: string
+        format: date-time
+        description: Last modification date
+        readOnly: true
+      addressSpace:
+        type: array
+        description: A list of CIDRs. It can only be one /26 CIDR (64 IP addresses) or bigger IP range in the customer space. Cannot be changed later. Only applicable to VPN.
+        items:
+          type: string
+      dns:
+        description: DNS Information. Only applicable to VPN infrastructures.
+        $ref: '#/definitions/DnsConfiguration'
+      connections:
+        type: array
+        description: List of VPN connections
+        items:
+          $ref: '#/definitions/VpnConnection'
+      statusDetails:
+        description: Error details. Present only when failed operations.
+        $ref: '#/definitions/ErrorDetailsRepresentation'
+        readOnly: true
+      _links:
+        type: object
+        readOnly: true
+        properties:
+          'http://ns.adobe.com/adobecloud/rel/program':
+            $ref: '#/definitions/HalLink'
+          self:
+            $ref: '#/definitions/HalLink'
+            description: This object's representation
+    description: An network infrastructure representation
+  NetworkInfrastructuresList:
+    type: object
+    properties:
+      _totalNumberOfItems:
+        type: integer
+        format: int32
+        description: The total number of embedded items
+      _embedded:
+        type: object
+        readOnly: true
+        properties:
+          networkInfrastructures:
+            type: array
+            items:
+              $ref: '#/definitions/NetworkInfrastructure'
+      _links:
+        type: object
+        readOnly: true
+        properties:
+          next:
+            $ref: '#/definitions/HalLink'
+            description: The next page of results.
+          prev:
+            $ref: '#/definitions/HalLink'
+            description: The previous page of results.
+          self:
+            $ref: '#/definitions/HalLink'
+            description: This object's representation
+  PortForwardRepresentation:
+    type: object
+    required:
+      - portDest
+      - portOrig
+    properties:
+      name:
+        type: string
+        example: smtp.example.com
+        description: Destination host
+        pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?([.][a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+      portDest:
+        type: integer
+        format: int32
+        example: 443
+        description: Destination port
+        maximum: 65535
+      portOrig:
+        type: integer
+        format: int32
+        example: 30710
+        description: Origin port for tunnel. Must be unique and in 30000-31000 range.
+        minimum: 30000
+        maximum: 31000
+  AdvancedNetworkingConfiguration:
+    type: object
+    properties:
+      programId:
+        type: string
+        example: '14'
+        description: Identifier of the program. Unique within the space.
+        readOnly: true
+      environmentId:
+        type: string
+        description: Identifier of the environment. Unique within the space.
+        readOnly: true
+      networkInfrastructureId:
+        type: string
+        example: '123'
+        description: Advanced network infrastructure used.
+        readOnly: true
+      nonProxyHosts:
+        type: array
+        description: 'A list of hosts that should be reached directly, bypassing the special VPN or egress routing. The patterns may start or end with a ''''*'''' for wildcards.'
+        items:
+          type: string
+        example:
+          - '*.example.com'
+          - '*.example.net'
+      portForwards:
+        type: array
+        description: List of port forwarding rules
+        items:
+          $ref: '#/definitions/PortForwardRepresentation'
+      advancedNetworkingEnabled:
+        type: boolean
+        description: Whether advanced networking is enabled in this environment
+        default: false
+        readOnly: true
+      _links:
+        type: object
+        readOnly: true
+        properties:
+          self:
+            $ref: '#/definitions/HalLink'
+            description: This object's representation
+    description: Describes the Advanced Networking configuration for an environment
+  AdvancedNetworkingConfigurationList:
+    type: object
+    properties:
+      _totalNumberOfItems:
+        type: integer
+        format: int32
+        description: The total number of embedded items
+      _embedded:
+        type: object
+        readOnly: true
+        properties:
+          networkingConfigurations:
+            type: array
+            items:
+              $ref: '#/definitions/AdvancedNetworkingConfiguration'
+      _links:
+        type: object
+        readOnly: true
+        properties:
+          next:
+            $ref: '#/definitions/HalLink'
+            description: The next page of results.
+          prev:
+            $ref: '#/definitions/HalLink'
+            description: The previous page of results.
+          self:
+            $ref: '#/definitions/HalLink'
+            description: This object's representation
+  ContentFlowValidationErrors:
+    type: object
+    properties:
+      errorCode:
+        type: string
+        description: content flow warning error code
+      message:
+        type: string
+        description: content flow warning message
+      details:
+        type: array
+        description: details
+        items:
+          type: string
+    description: The Content Flow Validation Errors
+  ContentFlowInfo:
+    type: object
+    properties:
+      validationErrors:
+        type: array
+        description: validationErrors
+        items:
+          $ref: '#/definitions/ContentFlowValidationErrors'
+    description: The Content Flow Info
+  ContentFlowResultDetails:
+    type: object
+    properties:
+      errorCode:
+        type: string
+        description: content flow error
+      message:
+        type: string
+        description: content flow error message
+      details:
+        type: array
+        description: details
+        items:
+          type: string
+      info:
+        description: info
+        $ref: '#/definitions/ContentFlowInfo'
+      phase:
+        type: string
+        description: phase
+    description: The Content Flow Result Details
+  ContentFlowInput:
+    type: object
+    properties:
+      contentSetId:
+        type: string
+      destEnvironmentId:
+        type: string
+      tier:
+        type: string
+        example: author
+        description: tier
+      includeACL:
+        type: boolean
+        description: includeACL
+        default: false
+      destProgramId:
+        type: string
+        description: destProgramId
+      mergeExcludePaths:
+        type: boolean
+        description: mergeExcludePaths
+        default: false
+      copyVersions:
+        type: boolean
+        description: copyVersions
+        default: false
+    description: Wraps the content flow execution arguments
+  CompatibilityCheckInput:
+    type: object
+    required:
+      - destinationEnvironmentId
+      - sourceEnvironmentId
+    properties:
+      sourceEnvironmentId:
+        type: string
+      destinationEnvironmentId:
+        type: string
+      tier:
+        type: string
+        enum:
+          - PUBLISH
+          - AUTHOR
+    description: Wraps the content copy compatibility check execution arguments.
+  CompatibilityCheckResponse:
+    type: object
+    properties:
+      sourceEnvironmentId:
+        type: string
+        example: '1234'
+        description: The source environment ID
+      sourceTopologyId:
+        type: string
+        example: 1a2b3cd4
+        description: The source topology ID
+      destinationEnvironmentId:
+        type: string
+        example: '5678'
+        description: The destination environment ID
+      destinationTopologyId:
+        type: string
+        example: 1a2b3cd4
+        description: The destination topology ID
+      tier:
+        type: string
+        example: author
+        description: tier
+      overallResult:
+        type: string
+        example: PASS
+        description: The overall result of the compatibility check
+      overallMessage:
+        type: string
+        example: Destination Topology cannot be prod.
+        description: The overall response message of the compatibility check
+      failedValidation:
+        type: string
+        example: TIER_NOT_ALLOWED
+        description: Error Code for the Failed Compatibility Check
+        enum:
+          - SOURCE_DISK_ORG
+          - TARGET_DISK_ORG
+          - SOURCE_REPO_TYPE
+          - TARGET_REPO_TYPE
+          - DATASTORE_TYPE
+          - BLOCK_TYPE
+          - TARGET_ENV
+          - REGION_CRITERIA
+          - CONNECTION_ERROR
+          - UNSUPPORTED_SKYLINE_ENV
+          - BAD_REQUEST
+          - ENVIRONMENT_NOT_FOUND
+          - PROGRAM_NOT_FOUND
+          - TIER_NOT_ALLOWED
+          - UNKNOWN
+      responseStatusCode:
+        type: integer
+        format: int32
+    description: Describes the Backflow Compatibility between two topologies.
+  ContentFlowLog:
+    type: object
+    properties:
+      jobType:
+        type: string
+        example: (import or export)
+        description: job type
+      programId:
+        type: integer
+        format: int64
+      contentFlowId:
+        type: integer
+        format: int64
+      _links:
+        type: object
+        readOnly: true
+        properties:
+          download:
+            description: Download Logs link
+            $ref: '#/definitions/HalLink'
+          logs/tail:
+            description: Tail Log link
+            $ref: '#/definitions/HalLink'
+    description: Log from Content Flow
+  Redirect:
+    type: object
+    required:
+      - redirect
+    properties:
+      redirect:
+        type: string
+        description: The url to redirect to.
+  NewFeedback:
+    type: object
+    required:
+      - rating
+      - type
+    properties:
+      createdAt:
+        type: string
+        description: Created time
+      id:
+        type: integer
+        description: Identifier of the feedback. Unique within the space.
+      rating:
+        type: integer
+        description: Rating values from 1 to 5
+      comment:
+        type: string
+        description: Feedback comment
+      type:
+        type: string
+        description: Type of feedback
+        enum:
+          - GO_LIVE
+      options:
+        type: object
+        description: Optional information about the feedback
+    description: Describes feedback
+  GoLiveDates:
+    type: object
+    properties:
+      plannedDate:
+        type: string
+        description: Date when go live is planned
+      actualDate:
+        type: string
+        description: Date when the program completed go live
+    description: Contains planned and actual go live dates of a program
+  PipelineUpdate:
+    type: object
+    description: Describe an update to a pipeline
+    properties:
+      phases:
+        type: array
+        description: Pipeline phases to update
+        items:
+          $ref: '#/definitions/PipelinePhaseUpdate'
+  EnvironmentVariableUpdate:
+    type: object
+    properties:
+      name:
+        type: string
+        example: MY_VAR1
+        description: 'Name of the variable. Can only consist of a-z, A-Z, _ and 0-9 and cannot begin with a number.'
+        pattern: '[a-zA-Z_][a-zA-Z_0-9]*'
+      value:
+        type: string
+        example: myValue
+        description: 'Value of the variable. Read-Write for non-secrets, write-only for secrets. The length of `secretString` values must be less than 500 characters. An empty value causes a variable to be deleted.'
+      type:
+        type: string
+        example: string
+        description: Type of the variable. Default `string` if missing. `secretString` variables are encrypted at rest. The type of a variable be changed after creation; the variable must be deleted and recreated.
+        enum:
+          - string
+          - secretString
+      service:
+        description: 'Service of the variable. When not provided, the variable applies to all services. Currently the values ''author'', ''publish'', and ''preview'' are supported. Note - this value is case-sensitive.'
+    description: 'A change (create, update, delete) of a named value on an Environment'
+  PipelineVariableUpdate:
+    type: object
+    properties:
+      name:
+        type: string
+        example: MY_VAR1
+        description: 'Name of the variable. Can only consist of a-z, A-Z, _ and 0-9 and cannot begin with a number.'
+        pattern: '[a-zA-Z_][a-zA-Z_0-9]*'
+      value:
+        type: string
+        example: myValue
+        description: 'Value of the variable. Read-Write for non-secrets, write-only for secrets. The length of `secretString` values must be less than 500 characters. An empty value causes a variable to be deleted.'
+      type:
+        type: string
+        example: string
+        description: Type of the variable. Default `string` if missing. `secretString` variables are encrypted at rest. The type of a variable be changed after creation; the variable must be deleted and recreated.
+        enum:
+          - string
+          - secretString
+    description: 'A change (create, update, delete) of a named value on a Pipeline'
+  PipelinePhaseUpdate:
+    type: object
+    required:
+      - type
+    description: Describes an update to a phase of a pipeline
+    properties:
+      name:
+        type: string
+        example: BUILD_1
+        description: Name of the phase
+      type:
+        type: string
+        example: BUILD
+        description: Type of the phase
+        enum:
+          - BUILD
+          - DEPLOY
+      repositoryId:
+        type: string
+        description: 'For BUILD phase type. Identifier of the source repository. The code from this repository will be build at the start of this phase. If not provided, the current value is retained.'
+      branch:
+        type: string
+        description: 'For BUILD phase type. Name of the tracked branch or a fully qualified git tag (e.g. refs/tags/v1). If not provided, the current value is retained.'
+      environmentId:
+        type: string
+        description: For DEPLOY phase type. Identifier of the target environment.
+      steps:
+        type: array
+        description: Steps to update within the phase.
+        items:
+          $ref: '#/definitions/PipelineStepUpdate'
+  PipelineStepUpdate:
+    type: object
+    required:
+      - type
+    description: Describes an update to a phase of a pipeline
+    properties:
+      name:
+        type: string
+        example: deploy
+        description: Name of the step
+      options:
+        type: object
+        description: Map of option parameters for the step
+        $ref: '#/definitions/PipelineStepUpdateOptions'
+  PipelineStepUpdateOptions:
+    type: object
+    properties:
+      dispatcherCacheInvalidationPaths:
+        type: array
+        items:
+          type: string
+        description: 'For deploy steps on AMS pipelines, list of paths to invalidate on dispatchers after package installation.'
+      dispatcherCacheFlushPaths:
+        type: array
+        items:
+          type: string
+        description: 'For deploy steps on AMS pipelines, list of paths to flush on dispatchers after package installation.'
+  EnableAdvancedNetworkingConfiguration:
+    type: object
+    properties:
+      nonProxyHosts:
+        type: array
+        description: 'A list of hosts that should be reached directly, bypassing the special VPN or egress routing. The patterns may start or end with a ''''*'''' for wildcards.'
+        items:
+          type: string
+        example:
+          - '*.example.com'
+          - '*.example.net'
+      portForwards:
+        type: array
+        description: List of port forwarding rules
+        items:
+          $ref: '#/definitions/PortForwardRepresentation'
+  PipelineExecutionStepStateDetails:
+    type: object
+    description: Details available for each step state. The set of properties available will vary by the step action.
+    properties:
+      deployCommands:
+        type: string
+        description: 'For deploy steps, a JSON array encoded as a string which lists the deployment activities expected to be performed.'
+      currentDeployCommandId:
+        type: string
+        description: 'For deploy steps, the current identifier from the deployCommands which is being executed.'
+      environmentUrls:
+        type: array
+        description: 'For deploy steps, the the set of URLs for the environment.'
+        items:
+          type: object
+          properties:
+            instanceType:
+              type: string
+            instanceUrl:
+              type: string
+      deploymentStepDescription:
+        type: string
+        description: 'For deploy steps, a JSON array encoded as a string which includes the detailed list of deployment activities which have been performed.'
+      input:
+        type: object
+        description: 'Input provided when advancing the step. See documentation at https://www.adobe.io/experience-cloud/cloud-manager/guides/api-usage/advancing-and-cancelling-steps/ for details.'
+  PipelineStepOptions:
+    type: object
+    description: Options for a pipeline step. Will vary based on step action and platform.
+    properties:
+      skipDetachingDispatchers:
+        type: boolean
+        description: 'For deploy steps on AMS pipelines, if true will not detach dispatcher from the load balancer.'
+      dispatcherCacheInvalidationPaths:
+        type: array
+        items:
+          type: string
+        description: 'For deploy steps on AMS pipelines, list of paths to invalidate on dispatchers after package installation.'
+      dispatcherCacheFlushPaths:
+        type: array
+        items:
+          type: string
+        description: 'For deploy steps on AMS pipelines, list of paths to flush on dispatchers after package installation.'
+      cse:
+        type: string
+        enum:
+          - MY_CSE
+          - ANY_CSE
+        description: 'For managed steps on AMS pipelines, which CSE will be responsible for CSE oversight.'
+      popularPagesWeight:
+        type: integer
+        format: int32
+        description: 'For loadTest steps on AMS pipelines, the percentage of performance test traffic which will be sent to the popular pages bucket.'
+      newPagesWeight:
+        type: integer
+        format: int32
+        description: 'For loadTest steps on AMS pipelines, the percentage of performance test traffic which will be sent to the new pages bucket.'
+      otherPagesWeight:
+        type: integer
+        format: int32
+        description: 'For loadTest steps on AMS pipelines, the percentage of performance test traffic which will be sent to the other pages bucket.'
+      imageAssetsWeight:
+        type: integer
+        format: int32
+        description: 'For assetsTest steps on AMS pipelines, the percentage of asset uploads which will be test images.'
+      pdfAssetsWeight:
+        type: integer
+        format: int32
+        description: 'For assetsTest steps on AMS pipelines, the percentage of asset uploads which will be test PDF files.'
+  NewProgram:
+    type: object
+    required:
+      - name
+      - type
+    description: Description of a new program to be created
+    properties:
+      name:
+        type: string
+        description: New program name
+        minLength: 0
+        maxLength: 64
+      type:
+        type: string
+        enum:
+          - aem_cloud_service
+      capabilities:
+        $ref: '#/definitions/ProgramCapabilities'
+      solutionNames:
+        type: array
+        description: List of solutions to be enabled on the new program.
+        items:
+          type: string
+          enum:
+            - aemsites
+            - aemassets
+      goLive:
+        description: Go live dates
+        $ref: '#/definitions/GoLiveDates'
+  NewEnvironment:
+    type: object
+    description: Description of a new program to be created
+    required:
+      - name
+      - region
+      - type
+    properties:
+      name:
+        type: string
+        example: acme-dev1
+        description: Name of the environment
+      type:
+        type: string
+        enum:
+          - dev
+          - stage
+          - prod
+          - rde
+      region:
+        type: string
+        example: va7
+        description: Region to create the environment.
+      description:
+        type: string
+        example: This is our primary development environment
+        description: Description of the environment
+  NewRegionDeployment:
+    type: object
+    description: Description of a new region deployment to be added in the environment
+    required:
+      - region
+    properties:
+      region:
+        type: string
+        example: va7
+        description: Region to be added in the environment
+  RegionDeploymentDeletion:
+    type: object
+    description: Description of region deployment to be deleted in the environment
+    required:
+      - id
+      - status
+    properties:
+      id:
+        type: string
+        description: Identifier of the  region deployment
+      status:
+        type: string
+        example: TO_DELETE
+        description: Status of the region deployment to be set
+  NewRelicSubAccountUser:
+    type: object
+    properties:
+      id:
+        type: string
+        example: '42'
+        description: Identifier of the New Relic sub account User
+      firstName:
+        type: string
+        example: John
+        description: First name of the New Relic sub account User
+      lastName:
+        type: string
+        example: Doe
+        description: Last name of the New Relic sub account User
+      email:
+        type: string
+        example: foobar@newrelic.com
+        description: email of the New Relic sub account user
+      role:
+        type: string
+        example: admin
+        description: Role of the New Relic sub account user
+      owner:
+        type: boolean
+        example: false
+        description: Owner detail of the New Relic sub account User
+        default: false
+    description: Describes __New Relic Sub-Account User__
+  NewContentSet:
+    type: object
+    properties:
+      name:
+        type: string
+        description: The name of this content set.
+      description:
+        type: string
+        description: The description of this content set.
+      paths:
+        type: array
+        description: Included asset paths
+        items:
+          $ref: '#/definitions/ContentSetPath'
+  ContentFlowLogs:
+    type: object
+    properties:
+      download:
+        $ref: '#/definitions/Redirect'
+        description: link to download logs
+      logs/tail:
+        $ref: '#/definitions/Redirect'
+        description: link to download tails log

--- a/swagger-specs/api.yaml
+++ b/swagger-specs/api.yaml
@@ -2,7 +2,7 @@ swagger: '2.0'
 info:
   version: 1.0.0
   title: Cloud Manager API
-  description: 'This API allows access to Cloud Manager programs, pipelines, and environments by an authorized technical account created through the Adobe I/O Console. The base url for this API is https://cloudmanager.adobe.io, e.g. to get the list of programs for an organization, you would make a GET request to https://cloudmanager.adobe.io/api/programs (with the correct set of headers as described below). This swagger file can be downloaded from https://raw.githubusercontent.com/AdobeDocs/cloudmanager-api-docs/main/swagger-specs/api.yaml.'
+  description: 'This API allows access to Cloud Manager programs, pipelines, and environments by an authorized technical account created through the Adobe I/O Console. The base url for this API is https://cloudmanager.adobe.io, e.g. to get the list of programs for an organization, you would make a GET request to https://cloudmanager.adobe.io/api/programs (with the correct set  of headers as described below). This swagger file can be downloaded from https://raw.githubusercontent.com/AdobeDocs/cloudmanager-api-docs/main/swagger-specs/api.yaml.'
 host: cloudmanager.adobe.io
 schemes:
   - https
@@ -31,13 +31,18 @@ tags:
   - name: Network infrastructure
   - name: Environment Advanced Networking Configuration
   - name: ContentSets
+  - name: Environment Advanced Networking Configuration
+  - name: ContentSets
 paths:
   /api/programs:
     get:
       tags:
         - Programs
       summary: Lists Programs
-      description: 'This API is deprecated and should no longer be used. Please use the [Lists Programs for Tenant API](#operation/getProgramsForTenant) instead.'
+      description: >-
+        This API is deprecated and should no longer be used. Please use the
+        [Lists Programs for Tenant API](#operation/getProgramsForTenant)
+        instead.
       operationId: getPrograms
       parameters:
         - name: x-gw-ims-org-id
@@ -47,12 +52,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -60,7 +69,7 @@ paths:
           description: successful operation
           schema:
             $ref: '#/definitions/ProgramList'
-  '/api/program/{programId}':
+  /api/program/{programId}:
     get:
       tags:
         - Programs
@@ -80,12 +89,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -114,12 +127,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -137,7 +154,7 @@ paths:
           description: Program not found.
         '412':
           description: Deletion not supported
-  '/api/program/{programId}/repositories':
+  /api/program/{programId}/repositories:
     get:
       tags:
         - Repositories
@@ -170,12 +187,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -183,7 +204,7 @@ paths:
           description: successful operation
           schema:
             $ref: '#/definitions/RepositoryList'
-  '/api/program/{programId}/repository/{repositoryId}':
+  /api/program/{programId}/repository/{repositoryId}:
     get:
       tags:
         - Repositories
@@ -208,12 +229,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -221,7 +246,7 @@ paths:
           description: successful operation
           schema:
             $ref: '#/definitions/Repository'
-  '/api/program/{programId}/repository/{repositoryId}/branches':
+  /api/program/{programId}/repository/{repositoryId}/branches:
     get:
       tags:
         - Branches
@@ -246,12 +271,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -259,12 +288,14 @@ paths:
           description: Successful retrieval of the list of repository branches
           schema:
             $ref: '#/definitions/BranchList'
-  '/api/program/{programId}/pipelines':
+  /api/program/{programId}/pipelines:
     get:
       tags:
         - Pipelines
       summary: List Pipelines
-      description: Returns all the pipelines that the requesting user has access to in an program
+      description: >-
+        Returns all the pipelines that the requesting user has access to in an
+        program
       operationId: getPipelines
       parameters:
         - name: programId
@@ -297,12 +328,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -310,7 +345,7 @@ paths:
           description: successful operation
           schema:
             $ref: '#/definitions/PipelineList'
-  '/api/program/{programId}/pipeline/{pipelineId}':
+  /api/program/{programId}/pipeline/{pipelineId}:
     get:
       tags:
         - Pipelines
@@ -335,12 +370,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -374,12 +413,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -415,12 +458,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -433,7 +480,7 @@ paths:
           description: successful operation
           schema:
             $ref: '#/definitions/Pipeline'
-  '/api/program/{programId}/pipeline/{pipelineId}/cache':
+  /api/program/{programId}/pipeline/{pipelineId}/cache:
     delete:
       tags:
         - Pipelines
@@ -458,18 +505,22 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
         default:
           description: successful operation
-  '/api/program/{programId}/pipeline/{pipelineId}/execution':
+  /api/program/{programId}/pipeline/{pipelineId}/execution:
     get:
       tags:
         - Pipeline Execution
@@ -494,12 +545,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -513,7 +568,9 @@ paths:
       tags:
         - Pipeline Execution
       summary: Start the pipeline
-      description: Starts the Pipeline. This works only if the pipeline is not already started.
+      description: >-
+        Starts the Pipeline. This works only if the pipeline is not already
+        started.
       operationId: startPipeline
       parameters:
         - name: programId
@@ -528,7 +585,9 @@ paths:
           type: string
         - name: pipelineExecutionMode
           in: query
-          description: The mode in which to run the execution. EMERGENCY mode will skip certain steps and is only available to select AMS customers.
+          description: >-
+            The mode in which to run the execution. EMERGENCY mode will skip
+            certain steps and is only available to select AMS customers.
           required: false
           type: string
           default: NORMAL
@@ -542,7 +601,9 @@ paths:
           type: string
         - name: sourceExecutionId
           in: query
-          description: Identifier of the source execution from which the execution will start
+          description: >-
+            Identifier of the source execution from which the execution will
+            start
           required: false
           type: string
         - name: x-gw-ims-org-id
@@ -552,12 +613,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -581,10 +646,12 @@ paths:
         '412':
           description: Pipeline is busy
         '503':
-          description: Pipeline execution cannot be started because of unplanned maintenance
+          description: >-
+            Pipeline execution cannot be started because of unplanned
+            maintenance
           schema:
             $ref: '#/definitions/SystemUnderMaintenanceExceptionMapper'
-  '/api/program/{programId}/pipeline/{pipelineId}/execution/{executionId}':
+  /api/program/{programId}/pipeline/{pipelineId}/execution/{executionId}:
     get:
       tags:
         - Pipeline Execution
@@ -614,12 +681,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -629,7 +700,7 @@ paths:
             $ref: '#/definitions/PipelineExecution'
         '404':
           description: No pipeline execution exits or unknown pipeline or application
-  '/api/program/{programId}/pipeline/{pipelineId}/execution/{executionId}/phase/{phaseId}/step/{stepId}':
+  /api/program/{programId}/pipeline/{pipelineId}/execution/{executionId}/phase/{phaseId}/step/{stepId}:
     get:
       tags:
         - Pipeline Execution
@@ -669,12 +740,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -686,12 +761,16 @@ paths:
           description: Missing permission for user to read step
         '404':
           description: Pipeline execution does not exist
-  '/api/program/{programId}/pipeline/{pipelineId}/execution/{executionId}/phase/{phaseId}/step/{stepId}/advance':
+  /api/program/{programId}/pipeline/{pipelineId}/execution/{executionId}/phase/{phaseId}/step/{stepId}/advance:
     put:
       tags:
         - Pipeline Execution
       summary: Advance
-      description: 'Post to this url in order to advance the current pipeline execution, if paused and waiting for user interaction. Link is present in output only in that case. The input depends on the actual reason for which the pipeline execution stopped.'
+      description: >-
+        Post to this url in order to advance the current pipeline execution, if
+        paused and waiting for user interaction. Link is present in output only
+        in that case. The input depends on the actual reason for which the
+        pipeline execution stopped.
       operationId: advancePipelineExecution
       parameters:
         - name: programId
@@ -721,7 +800,10 @@ paths:
           type: string
         - in: body
           name: body
-          description: 'Input for advance. See documentation at https://www.adobe.io/experience-cloud/cloud-manager/guides/api-usage/advancing-and-cancelling-steps/ for details.'
+          description: >-
+            Input for advance. See documentation at
+            https://www.adobe.io/experience-cloud/cloud-manager/guides/api-usage/advancing-and-cancelling-steps/
+            for details.
           required: true
           schema:
             type: object
@@ -732,12 +814,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -752,12 +838,14 @@ paths:
           description: Missing permission for user to advance the pipeline execution
         '404':
           description: No pipeline execution exits or unknown pipeline or program
-  '/api/program/{programId}/pipeline/{pipelineId}/execution/{executionId}/phase/{phaseId}/step/{stepId}/cancel':
+  /api/program/{programId}/pipeline/{pipelineId}/execution/{executionId}/phase/{phaseId}/step/{stepId}/cancel:
     put:
       tags:
         - Pipeline Execution
       summary: Cancel
-      description: Post to this url in order to cancel the current pipeline execution. Link is present in output only in that case.
+      description: >-
+        Post to this url in order to cancel the current pipeline execution. Link
+        is present in output only in that case.
       operationId: cancelPipelineExecutionStep
       parameters:
         - name: programId
@@ -787,7 +875,10 @@ paths:
           type: string
         - in: body
           name: body
-          description: 'Input for cancel. See documentation at https://www.adobe.io/experience-cloud/cloud-manager/guides/api-usage/advancing-and-cancelling-steps/ for details.'
+          description: >-
+            Input for cancel. See documentation at
+            https://www.adobe.io/experience-cloud/cloud-manager/guides/api-usage/advancing-and-cancelling-steps/
+            for details.
           required: true
           schema:
             type: object
@@ -798,12 +889,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -818,7 +913,7 @@ paths:
           description: Missing permission for user to cancel the current pipeline execution
         '404':
           description: No pipeline execution exits or unknown pipeline or program
-  '/api/program/{programId}/pipeline/{pipelineId}/execution/{executionId}/phase/{phaseId}/step/{stepId}/logs':
+  /api/program/{programId}/pipeline/{pipelineId}/execution/{executionId}/phase/{phaseId}/step/{stepId}/logs:
     get:
       tags:
         - Pipeline Execution
@@ -860,7 +955,10 @@ paths:
           in: header
           required: false
           type: string
-          description: 'Specify application/json in this header to receive a JSON response. Otherwise, a 307 response code will be returned with a Location header.'
+          description: >-
+            Specify application/json in this header to receive a JSON response.
+            Otherwise, a 307 response code will be returned with a Location
+            header.
         - name: x-gw-ims-org-id
           in: header
           description: IMS organization ID that the request is being made under.
@@ -868,12 +966,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -885,7 +987,7 @@ paths:
           description: Missing permission for user to read logs
         '404':
           description: Pipeline execution does not exist
-  '/api/program/{programId}/pipeline/{pipelineId}/execution/{executionId}/phase/{phaseId}/step/{stepId}/artifacts':
+  /api/program/{programId}/pipeline/{pipelineId}/execution/{executionId}/phase/{phaseId}/step/{stepId}/artifacts:
     get:
       tags:
         - Execution Artifacts
@@ -925,12 +1027,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -942,7 +1048,7 @@ paths:
           description: Missing permission for user to read artifacts
         '404':
           description: Pipeline execution does not exist
-  '/api/program/{programId}/pipeline/{pipelineId}/execution/{executionId}/phase/{phaseId}/step/{stepId}/artifact/{artifactId}':
+  /api/program/{programId}/pipeline/{pipelineId}/execution/{executionId}/phase/{phaseId}/step/{stepId}/artifact/{artifactId}:
     get:
       tags:
         - Execution Artifacts
@@ -991,12 +1097,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -1006,7 +1116,7 @@ paths:
           description: Missing permission for user to read artifact
         '404':
           description: Pipeline execution does not exist
-  '/api/program/{programId}/pipeline/{pipelineId}/execution/{executionId}/phase/{phaseId}/step/{stepId}/metrics':
+  /api/program/{programId}/pipeline/{pipelineId}/execution/{executionId}/phase/{phaseId}/step/{stepId}/metrics:
     get:
       tags:
         - Pipeline Execution
@@ -1046,12 +1156,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -1063,7 +1177,7 @@ paths:
           description: Missing permission for user to read metrics
         '404':
           description: Pipeline execution does not exist
-  '/api/program/{programId}/pipeline/{pipelineId}/executions':
+  /api/program/{programId}/pipeline/{pipelineId}/executions:
     get:
       tags:
         - Pipeline Execution
@@ -1099,12 +1213,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -1116,7 +1234,7 @@ paths:
           description: Missing permission for user to read executions
         '404':
           description: Pipeline does not exist
-  '/api/program/{programId}/environments':
+  /api/program/{programId}/environments:
     get:
       tags:
         - Environments
@@ -1148,12 +1266,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -1188,12 +1310,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -1208,7 +1334,7 @@ paths:
             $ref: '#/definitions/Environment'
         '400':
           description: Bad request
-  '/api/program/{programId}/environment/{environmentId}':
+  /api/program/{programId}/environment/{environmentId}:
     get:
       tags:
         - Environments
@@ -1233,12 +1359,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -1265,7 +1395,9 @@ paths:
           type: string
         - name: ignoreResourcesDeletionResult
           in: query
-          description: 'Ignore Resources Deletion Result option, delete flow does not fail if resources could not be deleted'
+          description: >-
+            Ignore Resources Deletion Result option, delete flow does not fail
+            if resources could not be deleted
           required: false
           type: boolean
           default: false
@@ -1276,12 +1408,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -1295,7 +1431,7 @@ paths:
             $ref: '#/definitions/BadRequestError'
         '404':
           description: Environment not found
-  '/api/program/{programId}/environment/{environmentId}/regionDeployments/{regionDeploymentId}':
+  /api/program/{programId}/environment/{environmentId}/regionDeployments/{regionDeploymentId}:
     get:
       tags:
         - Region Deployments
@@ -1325,12 +1461,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -1338,7 +1478,7 @@ paths:
           description: Successful retrieval of the region deployment for the environment
           schema:
             $ref: '#/definitions/RegionDeployment'
-  '/api/program/{programId}/environment/{environmentId}/regionDeployments':
+  /api/program/{programId}/environment/{environmentId}/regionDeployments:
     get:
       tags:
         - Region Deployments
@@ -1363,12 +1503,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -1408,12 +1552,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -1460,12 +1608,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -1484,7 +1636,7 @@ paths:
             $ref: '#/definitions/BadRequestError'
         '404':
           description: Region deployment not found for the given identifier
-  '/api/program/{programId}/environment/{environmentId}/logs':
+  /api/program/{programId}/environment/{environmentId}/logs:
     get:
       tags:
         - Environments
@@ -1531,12 +1683,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -1550,7 +1706,7 @@ paths:
             $ref: '#/definitions/BadRequestError'
         '404':
           description: Environment not found
-  '/api/program/{programId}/environment/{environmentId}/logs/download':
+  /api/program/{programId}/environment/{environmentId}/logs/download:
     get:
       tags:
         - Environments
@@ -1591,18 +1747,25 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
         - name: Accept
           required: false
           type: string
-          description: 'Specify application/json in this header to receive a JSON response. Otherwise, a 307 response code will be returned with a Location header.'
+          description: >-
+            Specify application/json in this header to receive a JSON response.
+            Otherwise, a 307 response code will be returned with a Location
+            header.
           in: header
       responses:
         '200':
@@ -1615,7 +1778,7 @@ paths:
             $ref: '#/definitions/BadRequestError'
         '404':
           description: Environment not found
-  '/api/program/{programId}/environment/{environmentId}/variables':
+  /api/program/{programId}/environment/{environmentId}/variables:
     get:
       tags:
         - Variables
@@ -1642,12 +1805,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -1661,7 +1828,9 @@ paths:
       tags:
         - Variables
       summary: Patch User Environment Variables
-      description: 'Modify multiple environment variables (Cloud Service only). To delete a variable, include it with an empty value.'
+      description: >-
+        Modify multiple environment variables (Cloud Service only). To delete a
+        variable, include it with an empty value.
       operationId: patchEnvironmentVariables
       parameters:
         - name: programId
@@ -1676,7 +1845,10 @@ paths:
           type: string
         - in: body
           name: body
-          description: 'The list of variables to add, modify, or remove. It is not necessary to send variables here which are not changing. The length of `secretString` values must be less than 500 characters.'
+          description: >-
+            The list of variables to add, modify, or remove. It is not necessary
+            to send variables here which are not changing. The length of
+            `secretString` values must be less than 500 characters.
           required: true
           schema:
             type: array
@@ -1689,12 +1861,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -1707,12 +1883,14 @@ paths:
           description: Successful setting of variables
         '404':
           description: Environment not found
-  '/api/program/{programId}/environment/{environmentId}/reset':
+  /api/program/{programId}/environment/{environmentId}/reset:
     put:
       tags:
         - Rapid Development Environments
       summary: Reset Rapid Development Environment
-      description: Reset Rapid Development Environment. Also updates the RDE to the latest AEM release.
+      description: >-
+        Reset Rapid Development Environment. Also updates the RDE to the latest
+        AEM release.
       operationId: resetRde
       parameters:
         - name: programId
@@ -1732,12 +1910,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -1745,7 +1927,7 @@ paths:
           description: Successfully reset RDE
         '404':
           description: Environment not found
-  '/api/program/{programId}/environment/{environmentId}/restorePoints':
+  /api/program/{programId}/environment/{environmentId}/restorePoints:
     get:
       tags:
         - Environment Restore From Backup
@@ -1770,12 +1952,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -1785,7 +1971,7 @@ paths:
             $ref: '#/definitions/RestorePointsList'
         '404':
           description: Resource not found
-  '/api/program/{programId}/environment/{environmentId}/restoreExecution/{restoreId}':
+  /api/program/{programId}/environment/{environmentId}/restoreExecution/{restoreId}:
     get:
       tags:
         - Environment Restore From Backup
@@ -1815,12 +2001,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -1828,7 +2018,7 @@ paths:
           description: successful operation
           schema:
             $ref: '#/definitions/RestoreExecution'
-  '/api/program/{programId}/environment/{environmentId}/restoreExecution/{restoreId}/logs':
+  /api/program/{programId}/environment/{environmentId}/restoreExecution/{restoreId}/logs:
     get:
       tags:
         - Environment Restore From Backup
@@ -1862,18 +2052,22 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
         default:
           description: successful operation
-  '/api/program/{programId}/environment/{environmentId}/restoreExecutions':
+  /api/program/{programId}/environment/{environmentId}/restoreExecutions:
     get:
       tags:
         - Environment Restore From Backup
@@ -1911,12 +2105,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -1924,7 +2122,7 @@ paths:
           description: successful operation
           schema:
             $ref: '#/definitions/RestoreExecutionList'
-  '/api/program/{programId}/environment/{environmentId}/restoreExecution':
+  /api/program/{programId}/environment/{environmentId}/restoreExecution:
     put:
       tags:
         - Environment Restore From Backup
@@ -1955,12 +2153,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -1977,7 +2179,7 @@ paths:
           description: Environment not found
         '412':
           description: Restore precondition failed
-  '/api/program/{programId}/pipeline/{pipelineId}/variables':
+  /api/program/{programId}/pipeline/{pipelineId}/variables:
     get:
       tags:
         - Variables
@@ -2004,12 +2206,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -2023,7 +2229,9 @@ paths:
       tags:
         - Variables
       summary: Patch User Pipeline Variables
-      description: 'Modify multiple pipeline variables. To delete a variable, include it with an empty value.'
+      description: >-
+        Modify multiple pipeline variables. To delete a variable, include it
+        with an empty value.
       operationId: patchPipelineVariables
       parameters:
         - name: programId
@@ -2038,7 +2246,10 @@ paths:
           type: string
         - in: body
           name: body
-          description: 'The list of variables to add, modify, or remove. It is not necessary to send variables here which are not changing. The length of `secretString` values must be less than 500 characters.'
+          description: >-
+            The list of variables to add, modify, or remove. It is not necessary
+            to send variables here which are not changing. The length of
+            `secretString` values must be less than 500 characters.
           required: true
           schema:
             type: array
@@ -2051,12 +2262,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -2069,7 +2284,7 @@ paths:
           description: Successful setting of variables
         '404':
           description: Pipeline not found
-  '/api/program/{programId}/ipAllowlist/{ipAllowlistId}':
+  /api/program/{programId}/ipAllowlist/{ipAllowlistId}:
     get:
       tags:
         - IP Allowlist
@@ -2094,12 +2309,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -2139,12 +2358,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -2185,12 +2408,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -2200,7 +2427,7 @@ paths:
             $ref: '#/definitions/IPAllowedList'
         '404':
           description: Resource not found
-  '/api/program/{programId}/ipAllowlist/{ipAllowlistId}/binding/{ipAllowlistBindingId}':
+  /api/program/{programId}/ipAllowlist/{ipAllowlistId}/binding/{ipAllowlistBindingId}:
     get:
       tags:
         - IP Allowlist Binding
@@ -2230,12 +2457,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -2274,12 +2505,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -2289,12 +2524,14 @@ paths:
             $ref: '#/definitions/IPAllowedListBinding'
         '404':
           description: IP Allowlist not found
-  '/api/program/{programId}/ipAllowlist/{ipAllowlistId}/binding/{ipAllowlistBindingId}/retry':
+  /api/program/{programId}/ipAllowlist/{ipAllowlistId}/binding/{ipAllowlistBindingId}/retry:
     put:
       tags:
         - IP Allowlist Binding
       summary: Retry IP Allowlist binding action
-      description: Retry the IP Allowlist binding action for the program and IP Allowlist id
+      description: >-
+        Retry the IP Allowlist binding action for the program and IP Allowlist
+        id
       operationId: retryIPAllowlistBinding
       parameters:
         - name: programId
@@ -2319,12 +2556,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -2334,7 +2575,7 @@ paths:
             $ref: '#/definitions/IPAllowedListBinding'
         '404':
           description: IP Allowlist not found
-  '/api/program/{programId}/ipAllowlist/{ipAllowlistId}/bindings':
+  /api/program/{programId}/ipAllowlist/{ipAllowlistId}/bindings:
     get:
       tags:
         - IP Allowlist Binding
@@ -2359,12 +2600,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -2404,12 +2649,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -2432,7 +2681,7 @@ paths:
           description: Environment not found
         '412':
           description: Creating IP Allowlists for non cloud programs is not supported
-  '/api/program/{programId}/ipAllowlists':
+  /api/program/{programId}/ipAllowlists:
     get:
       tags:
         - IP Allowlist
@@ -2452,12 +2701,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -2492,12 +2745,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -2520,7 +2777,7 @@ paths:
           description: Program not found
         '412':
           description: Creating IP Allowlists for non cloud programs is not supported
-  '/api/program/{programId}/domainNames':
+  /api/program/{programId}/domainNames:
     get:
       tags:
         - Domain Names
@@ -2553,12 +2810,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -2591,12 +2852,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -2611,7 +2876,7 @@ paths:
             $ref: '#/definitions/DomainName'
         '404':
           description: Resource not found
-  '/api/program/{programId}/domainName/{domainNameId}':
+  /api/program/{programId}/domainName/{domainNameId}:
     get:
       tags:
         - Domain Names
@@ -2636,12 +2901,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -2679,12 +2948,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -2727,12 +3000,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -2742,7 +3019,7 @@ paths:
             $ref: '#/definitions/DomainName'
         '404':
           description: Resource not found
-  '/api/program/{programId}/domainName/{domainNameId}/deploy':
+  /api/program/{programId}/domainName/{domainNameId}/deploy:
     post:
       tags:
         - Domain Names
@@ -2767,12 +3044,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -2782,7 +3063,7 @@ paths:
             $ref: '#/definitions/DomainName'
         '404':
           description: Resource not found
-  '/api/program/{programId}/domainName/{domainNameId}/verify':
+  /api/program/{programId}/domainName/{domainNameId}/verify:
     post:
       tags:
         - Domain Names
@@ -2807,12 +3088,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -2826,7 +3111,7 @@ paths:
             $ref: '#/definitions/DomainName'
         '404':
           description: Resource not found
-  '/api/program/{programId}/domainNames/validate':
+  /api/program/{programId}/domainNames/validate:
     post:
       tags:
         - Domain Names
@@ -2852,12 +3137,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -2872,7 +3161,7 @@ paths:
             $ref: '#/definitions/DomainName'
         '404':
           description: Resource not found
-  '/api/program/{programId}/certificate/{certificateId}':
+  /api/program/{programId}/certificate/{certificateId}:
     get:
       tags:
         - SSLCertificates
@@ -2897,12 +3186,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -2910,6 +3203,10 @@ paths:
           description: successful operation
           schema:
             $ref: '#/definitions/SslCertificate'
+        '404':
+          description: Certificate not found
+          schema:
+            $ref: '#/definitions/SslCertificateNotFoundException'
     put:
       tags:
         - SSLCertificates
@@ -2940,12 +3237,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -2960,6 +3261,8 @@ paths:
             $ref: '#/definitions/SslCertificate'
         '404':
           description: Resource not found
+          schema:
+            $ref: '#/definitions/SslCertificateNotFoundException'
     delete:
       tags:
         - SSLCertificates
@@ -2984,22 +3287,32 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
+        '200':
+          description: Certificate deleted
+          schema:
+            $ref: '#/definitions/SslCertificateRepresentation'
         '204':
           description: Certificate deleted
           schema:
             $ref: '#/definitions/SslCertificate'
         '404':
           description: Resource not found
-  '/api/program/{programId}/certificates':
+          schema:
+            $ref: '#/definitions/SslCertificateNotFoundException'
+  /api/program/{programId}/certificates:
     get:
       tags:
         - SSLCertificates
@@ -3037,12 +3350,30 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
+          required: true
+          type: string
+        - name: Authorization
+          in: header
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
+          required: true
+          type: string
+        - name: x-api-key
+          in: header
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -3077,12 +3408,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -3091,13 +3426,17 @@ paths:
           required: true
           type: string
       responses:
+        '200':
+          description: successful operation
+          schema:
+            $ref: '#/definitions/SslCertificateRepresentation'
         '201':
           description: Certificate created
           schema:
             $ref: '#/definitions/SslCertificate'
         '404':
           description: Program not found
-  '/api/program/{programId}/feedbacks':
+  /api/program/{programId}/feedbacks:
     post:
       tags:
         - Programs
@@ -3123,12 +3462,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -3141,7 +3484,7 @@ paths:
           description: Invalid request
         '404':
           description: Application not found
-  '/api/program/{programId}/newRelicUsers':
+  /api/program/{programId}/newRelicUsers:
     get:
       tags:
         - Programs
@@ -3161,12 +3504,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -3177,23 +3524,33 @@ paths:
         '400':
           description: The request is malformed.
         '401':
-          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          description: >-
+            The request has not been applied because it lacks valid
+            authentication credentials for the target resource.
         '403':
           description: The requester is not authorized to access the resource.
         '405':
-          description: Client sent a request using a HTTP method that the server doesn't support.
+          description: >-
+            Client sent a request using a HTTP method that the server doesn't
+            support.
         '406':
-          description: Unacceptable content type. Client sent an Accept header for a content type which does not exist on the server.
+          description: >-
+            Unacceptable content type. Client sent an Accept header for a
+            content type which does not exist on the server.
         '422':
           description: Unprocessable Entity
         '500':
           description: This is an indicator of a server-side error.
         '502':
-          description: This is an indicator that the back-end service did not send a valid response.
+          description: >-
+            This is an indicator that the back-end service did not send a valid
+            response.
         '503':
           description: This is an indicator of a potential server overload.
         '504':
-          description: This is an indicator that the back-end service did not complete a response within an allowed time period.
+          description: >-
+            This is an indicator that the back-end service did not complete a
+            response within an allowed time period.
     patch:
       tags:
         - Programs
@@ -3219,12 +3576,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -3242,21 +3603,29 @@ paths:
         '400':
           description: The request is malformed.
         '401':
-          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          description: >-
+            The request has not been applied because it lacks valid
+            authentication credentials for the target resource.
         '403':
           description: The requester is not authorized to access the resource.
         '404':
           description: Program not found
         '406':
-          description: Unacceptable content type. Client sent an Accept header for a content type which does not exist on the server.
+          description: >-
+            Unacceptable content type. Client sent an Accept header for a
+            content type which does not exist on the server.
         '500':
           description: This is an indicator of a server-side error.
         '502':
-          description: This is an indicator that the back-end service did not send a valid response.
+          description: >-
+            This is an indicator that the back-end service did not send a valid
+            response.
         '503':
           description: This is an indicator of a potential server overload.
         '504':
-          description: This is an indicator that the back-end service did not complete a response within an allowed time period.
+          description: >-
+            This is an indicator that the back-end service did not complete a
+            response within an allowed time period.
   /api/tenants:
     get:
       tags:
@@ -3272,12 +3641,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -3285,7 +3658,7 @@ paths:
           description: Successful retrieval of tenant list
           schema:
             $ref: '#/definitions/TenantList'
-  '/api/tenant/{tenantId}':
+  /api/tenant/{tenantId}:
     get:
       tags:
         - Tenants
@@ -3305,12 +3678,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -3320,7 +3697,7 @@ paths:
             $ref: '#/definitions/Tenant'
         '404':
           description: Tenant not found
-  '/api/tenant/{tenantId}/programs':
+  /api/tenant/{tenantId}/programs:
     get:
       tags:
         - Programs
@@ -3340,12 +3717,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -3380,12 +3761,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -3400,12 +3785,14 @@ paths:
             $ref: '#/definitions/Program'
         '409':
           description: Program already exists.
-  '/api/program/{programId}/regions':
+  /api/program/{programId}/regions:
     get:
       tags:
         - Regions
       summary: Lists Regions
-      description: Returns all Regions that can be used to create environments for this program.
+      description: >-
+        Returns all Regions that can be used to create environments for this
+        program.
       operationId: getProgramRegions
       parameters:
         - name: programId
@@ -3420,12 +3807,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -3433,7 +3824,7 @@ paths:
           description: successful operation
           schema:
             $ref: '#/definitions/RegionsList'
-  '/api/program/{programId}/networkInfrastructures':
+  /api/program/{programId}/networkInfrastructures:
     get:
       tags:
         - Network infrastructure
@@ -3453,12 +3844,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -3493,12 +3888,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -3513,7 +3912,7 @@ paths:
             $ref: '#/definitions/NetworkInfrastructure'
         '404':
           description: Resource not found
-  '/api/program/{programId}/networkInfrastructure/{networkInfrastructureId}':
+  /api/program/{programId}/networkInfrastructure/{networkInfrastructureId}:
     get:
       tags:
         - Network infrastructure
@@ -3538,12 +3937,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -3583,12 +3986,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -3627,12 +4034,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -3648,7 +4059,7 @@ paths:
           description: Network Infrastructure cannot be deleted
         '404':
           description: Network Infrastructure not found
-  '/api/program/{programId}/environment/{environmentId}/advancedNetworking':
+  /api/program/{programId}/environment/{environmentId}/advancedNetworking:
     get:
       tags:
         - Environment Advanced Networking Configuration
@@ -3673,12 +4084,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -3718,12 +4133,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -3764,12 +4183,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -3781,7 +4204,7 @@ paths:
           description: Validation exception
         '404':
           description: Resource not found
-  '/api/program/{programId}/contentSets':
+  /api/program/{programId}/contentSets:
     get:
       tags:
         - ContentSets
@@ -3801,12 +4224,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -3841,12 +4268,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -3863,7 +4294,7 @@ paths:
           description: Bad request
         '404':
           description: Program not found
-  '/api/program/{programId}/contentSet/{contentSetId}':
+  /api/program/{programId}/contentSet/{contentSetId}:
     get:
       tags:
         - ContentSets
@@ -3888,12 +4319,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -3935,12 +4370,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -3981,12 +4420,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -3998,7 +4441,7 @@ paths:
           description: Bad request
         '404':
           description: Content set not found
-  '/api/program/{programId}/contentFlows':
+  /api/program/{programId}/contentFlows:
     get:
       tags:
         - ContentSets
@@ -4031,12 +4474,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -4046,7 +4493,7 @@ paths:
             $ref: '#/definitions/ContentFlowList'
         '400':
           description: Bad request
-  '/api/program/{programId}/environment/{environmentId}/contentFlow':
+  /api/program/{programId}/environment/{environmentId}/contentFlow:
     post:
       tags:
         - ContentSets
@@ -4077,12 +4524,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -4101,7 +4552,7 @@ paths:
           description: The requester is not authorized to access the resource.
         '404':
           description: Program not found
-  '/api/program/{programId}/contentFlow/checkCompatibility':
+  /api/program/{programId}/contentFlow/checkCompatibility:
     post:
       tags:
         - ContentSets
@@ -4127,12 +4578,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
         - name: Content-Type
@@ -4151,7 +4606,7 @@ paths:
             $ref: '#/definitions/BadRequestError'
         '404':
           description: Program not found
-  '/api/program/{programId}/contentFlow/{contentFlowId}':
+  /api/program/{programId}/contentFlow/{contentFlowId}:
     get:
       tags:
         - ContentSets
@@ -4176,12 +4631,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -4215,12 +4674,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -4230,7 +4693,7 @@ paths:
             $ref: '#/definitions/ContentFlow'
         '400':
           description: Bad request
-  '/api/program/{programId}/contentFlow/{contentFlowId}/logs':
+  /api/program/{programId}/contentFlow/{contentFlowId}/logs:
     get:
       tags:
         - ContentSets
@@ -4250,7 +4713,7 @@ paths:
           type: string
         - name: jobType
           in: query
-          description: 'Job type (import, export)'
+          description: Job type (import, export)
           required: true
           type: string
         - name: x-gw-ims-org-id
@@ -4260,12 +4723,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -4279,7 +4746,7 @@ paths:
             $ref: '#/definitions/BadRequestError'
         '404':
           description: Program not found.
-  '/api/program/{programId}/contentFlow/{contentFlowId}/logs/download':
+  /api/program/{programId}/contentFlow/{contentFlowId}/logs/download:
     get:
       tags:
         - ContentSets
@@ -4299,7 +4766,7 @@ paths:
           type: string
         - name: jobType
           in: query
-          description: 'Job type (import, export)'
+          description: Job type (import, export)
           required: true
           type: string
         - name: Accept
@@ -4313,12 +4780,16 @@ paths:
           type: string
         - name: Authorization
           in: header
-          description: 'Bearer [token] - An access token for the technical account created through integration with Adobe IO'
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
           required: true
           type: string
         - name: x-api-key
           in: header
-          description: IMS Client ID (API Key) which is subscribed to consume services on console.adobe.io
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
           required: true
           type: string
       responses:
@@ -4333,6 +4804,1034 @@ paths:
             $ref: '#/definitions/BadRequestError'
         '404':
           description: Program not found.
+  /api/program/{programId}/domains:
+    get:
+      tags:
+        - Domain
+      summary: Get list of domains
+      description: ''
+      operationId: getDomain
+      parameters:
+        - name: programId
+          in: path
+          description: Identifier of program id
+          required: true
+          type: string
+        - name: name
+          in: query
+          description: Domain name
+          required: false
+          type: string
+        - name: anyVerified
+          in: query
+          description: Filter any verified
+          required: false
+          type: boolean
+        - name: isTxt
+          in: query
+          description: Is TXT verified
+          required: false
+          type: boolean
+        - name: isAcme
+          in: query
+          description: Is ACME verified
+          required: false
+          type: boolean
+        - name: x-gw-ims-org-id
+          in: header
+          description: IMS organization ID that the request is being made under.
+          required: true
+          type: string
+        - name: Authorization
+          in: header
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
+          required: true
+          type: string
+        - name: x-api-key
+          in: header
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
+          required: true
+          type: string
+      responses:
+        '200':
+          description: List of domains received
+          schema:
+            $ref: '#/definitions/Domain'
+    post:
+      tags:
+        - Domain
+      summary: Create a domain
+      description: ''
+      operationId: createDomain
+      parameters:
+        - name: programId
+          in: path
+          description: Identifier of program
+          required: true
+          type: string
+        - in: body
+          name: body
+          description: Payload for creating a domain
+          required: true
+          schema:
+            $ref: '#/definitions/DomainCreate'
+        - name: x-gw-ims-org-id
+          in: header
+          description: IMS organization ID that the request is being made under.
+          required: true
+          type: string
+        - name: Authorization
+          in: header
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
+          required: true
+          type: string
+        - name: x-api-key
+          in: header
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
+          required: true
+          type: string
+        - name: Content-Type
+          in: header
+          description: Must always be application/json
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Domain created
+          schema:
+            $ref: '#/definitions/Domain'
+        '404':
+          description: Program not found
+        '409':
+          description: Domain already exists
+  /api/program/{programId}/domain/{domain-id}:
+    get:
+      tags:
+        - Domain
+      summary: Get domain
+      description: ''
+      operationId: getDomain
+      parameters:
+        - name: programId
+          in: path
+          description: Identifier of program id
+          required: true
+          type: string
+        - name: domain-id
+          in: path
+          description: Identifier of domain id
+          required: true
+          type: string
+        - name: x-gw-ims-org-id
+          in: header
+          description: IMS organization ID that the request is being made under.
+          required: true
+          type: string
+        - name: Authorization
+          in: header
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
+          required: true
+          type: string
+        - name: x-api-key
+          in: header
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Domain received
+          schema:
+            $ref: '#/definitions/Domain'
+        '404':
+          description: Domain not found
+    put:
+      tags:
+        - Domain
+      summary: Update domain
+      description: ''
+      operationId: modifyDomain
+      parameters:
+        - name: programId
+          in: path
+          description: Identifier of program id
+          required: true
+          type: string
+        - name: domain-id
+          in: path
+          description: Identifier of domain id
+          required: true
+          type: string
+        - in: body
+          name: body
+          description: Domain Update Body
+          required: true
+          schema:
+            $ref: '#/definitions/UpdateaDomain''snameorlabel'
+        - name: x-gw-ims-org-id
+          in: header
+          description: IMS organization ID that the request is being made under.
+          required: true
+          type: string
+        - name: Authorization
+          in: header
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
+          required: true
+          type: string
+        - name: x-api-key
+          in: header
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
+          required: true
+          type: string
+        - name: Content-Type
+          in: header
+          description: Must always be application/json
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Domain updated
+          schema:
+            $ref: '#/definitions/Domain'
+        '404':
+          description: Program not found
+    delete:
+      tags:
+        - Domain
+      summary: Delete a domain
+      description: ''
+      operationId: deleteDomain
+      parameters:
+        - name: programId
+          in: path
+          description: Identifier of program id
+          required: true
+          type: string
+        - name: domain-id
+          in: path
+          description: Identifier of domain id
+          required: true
+          type: string
+        - name: x-gw-ims-org-id
+          in: header
+          description: IMS organization ID that the request is being made under.
+          required: true
+          type: string
+        - name: Authorization
+          in: header
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
+          required: true
+          type: string
+        - name: x-api-key
+          in: header
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Domain deleted
+          schema:
+            $ref: '#/definitions/Response'
+  /api/program/{programId}/domain/{domain-id}/validate:
+    put:
+      tags:
+        - Domain
+      summary: Check validation
+      description: ''
+      operationId: domainValidationToken
+      parameters:
+        - name: programId
+          in: path
+          description: Identifier of program id
+          required: true
+          type: string
+        - name: domain-id
+          in: path
+          description: Identifier of domain id
+          required: true
+          type: string
+        - in: body
+          name: body
+          description: Payload for validation operation
+          required: true
+          schema:
+            $ref: '#/definitions/DomainTokenValidationBody'
+        - name: x-gw-ims-org-id
+          in: header
+          description: IMS organization ID that the request is being made under.
+          required: true
+          type: string
+        - name: Authorization
+          in: header
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
+          required: true
+          type: string
+        - name: x-api-key
+          in: header
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
+          required: true
+          type: string
+        - name: Content-Type
+          in: header
+          description: Must always be application/json
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Validation is completed
+          schema:
+            $ref: '#/definitions/Domain'
+        '404':
+          description: Program not found
+  /api/program/{programId}/domain/{domain-id}/validation:
+    post:
+      tags:
+        - Domain
+      summary: Creates validation token
+      description: ''
+      operationId: domainValidationToken
+      parameters:
+        - name: programId
+          in: path
+          description: Identifier of program id
+          required: true
+          type: string
+        - name: domain-id
+          in: path
+          description: Identifier of domain id
+          required: true
+          type: string
+        - in: body
+          name: body
+          description: Payload for validation operation
+          required: true
+          schema:
+            $ref: '#/definitions/DomainTokenValidationBody'
+        - name: x-gw-ims-org-id
+          in: header
+          description: IMS organization ID that the request is being made under.
+          required: true
+          type: string
+        - name: Authorization
+          in: header
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
+          required: true
+          type: string
+        - name: x-api-key
+          in: header
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
+          required: true
+          type: string
+        - name: Content-Type
+          in: header
+          description: Must always be application/json
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Created validation token
+          schema:
+            $ref: '#/definitions/Domain'
+        '404':
+          description: Program Not found
+  /api/program/{programId}/domain-mapping/{domainMappingId}:
+    get:
+      tags:
+        - Domain Mappings - CDN Configurations
+      summary: Get domain mapping
+      description: ''
+      operationId: getDomainMappingById
+      parameters:
+        - name: programId
+          in: path
+          description: Identifier of program
+          required: true
+          type: integer
+          format: int64
+        - name: domainMappingId
+          in: path
+          description: Identifier of domain mapping
+          required: true
+          type: integer
+          format: int64
+        - name: x-gw-ims-org-id
+          in: header
+          description: IMS organization ID that the request is being made under.
+          required: true
+          type: string
+        - name: Authorization
+          in: header
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
+          required: true
+          type: string
+        - name: x-api-key
+          in: header
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Domain Mapping retrieved
+          schema:
+            $ref: '#/definitions/DomainMapping'
+        '404':
+          description: Domain Mapping not found
+    put:
+      tags:
+        - Domain Mappings - CDN Configurations
+      summary: Update domain mapping
+      description: ''
+      operationId: updateDomainMapping
+      parameters:
+        - name: programId
+          in: path
+          description: Identifier of program
+          required: true
+          type: integer
+          format: int64
+        - name: domainMappingId
+          in: path
+          description: Identifier of domain mapping
+          required: true
+          type: integer
+          format: int64
+        - in: body
+          name: body
+          description: Payload for updating a domain mapping
+          required: true
+          schema:
+            $ref: '#/definitions/Updateadomainmapping'
+        - name: x-gw-ims-org-id
+          in: header
+          description: IMS organization ID that the request is being made under.
+          required: true
+          type: string
+        - name: Authorization
+          in: header
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
+          required: true
+          type: string
+        - name: x-api-key
+          in: header
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
+          required: true
+          type: string
+        - name: Content-Type
+          in: header
+          description: Must always be application/json
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Domain Mapping updated
+          schema:
+            $ref: '#/definitions/DomainMapping'
+        '404':
+          description: Domain Mapping not found
+    delete:
+      tags:
+        - Domain Mappings - CDN Configurations
+      summary: Delete domain mapping
+      description: ''
+      operationId: deleteDomainMapping
+      parameters:
+        - name: programId
+          in: path
+          description: Identifier of program
+          required: true
+          type: integer
+          format: int64
+        - name: domainMappingId
+          in: path
+          description: Identifier of domain mapping
+          required: true
+          type: integer
+          format: int64
+        - name: x-gw-ims-org-id
+          in: header
+          description: IMS organization ID that the request is being made under.
+          required: true
+          type: string
+        - name: Authorization
+          in: header
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
+          required: true
+          type: string
+        - name: x-api-key
+          in: header
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Domain Mapping deleted
+          schema:
+            $ref: '#/definitions/DomainMapping'
+        '404':
+          description: Domain Mapping not found
+  /api/program/{programId}/domain-mapping/{domainMappingId}/verify:
+    put:
+      tags:
+        - Domain Mappings - CDN Configurations
+      summary: Check if customer made the required DNS changes
+      description: ''
+      operationId: validateHelixDomain
+      parameters:
+        - name: programId
+          in: path
+          description: Identifier of program
+          required: true
+          type: integer
+          format: int64
+        - name: domainMappingId
+          in: path
+          description: Identifier of domain mapping
+          required: true
+          type: integer
+          format: int64
+        - name: x-gw-ims-org-id
+          in: header
+          description: IMS organization ID that the request is being made under.
+          required: true
+          type: string
+        - name: Authorization
+          in: header
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
+          required: true
+          type: string
+        - name: x-api-key
+          in: header
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
+          required: true
+          type: string
+      responses:
+        '200':
+          description: DNS changes were successfully made
+          schema:
+            $ref: '#/definitions/DomainMapping'
+        '404':
+          description: Program not found
+  /api/program/{programId}/domain-mappings:
+    get:
+      tags:
+        - Domain Mappings - CDN Configurations
+      summary: List of domain mappings
+      description: ''
+      operationId: getAllDomainMappingsByProgramId
+      parameters:
+        - name: programId
+          in: path
+          description: Identifier of program
+          required: true
+          type: integer
+          format: int64
+        - name: x-gw-ims-org-id
+          in: header
+          description: IMS organization ID that the request is being made under.
+          required: true
+          type: string
+        - name: Authorization
+          in: header
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
+          required: true
+          type: string
+        - name: x-api-key
+          in: header
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
+          required: true
+          type: string
+      responses:
+        '200':
+          description: List of domain mappings retrieved
+          schema:
+            $ref: '#/definitions/DomainMappingList'
+    post:
+      tags:
+        - Domain Mappings - CDN Configurations
+      summary: Create domain mapping
+      description: ''
+      operationId: createDomainMapping
+      parameters:
+        - name: programId
+          in: path
+          description: Identifier of program
+          required: true
+          type: integer
+          format: int64
+        - in: body
+          name: body
+          description: Payload for creating a domain mapping
+          required: true
+          schema:
+            $ref: '#/definitions/Createanewdomainmapping'
+        - name: x-gw-ims-org-id
+          in: header
+          description: IMS organization ID that the request is being made under.
+          required: true
+          type: string
+        - name: Authorization
+          in: header
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
+          required: true
+          type: string
+        - name: x-api-key
+          in: header
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
+          required: true
+          type: string
+        - name: Content-Type
+          in: header
+          description: Must always be application/json
+          required: true
+          type: string
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            $ref: '#/definitions/DomainMapping'
+        '201':
+          description: Domain Mapping created
+          schema:
+            $ref: '#/definitions/DomainMapping'
+  /api/program/{programId}/environment/{environmentId}/domain-mappings:
+    get:
+      tags:
+        - Domain Mappings - CDN Configurations
+      summary: List of domain mappings by environment
+      description: ''
+      operationId: getAllDomainMappingsByProgramIdAndEnvironmentId
+      parameters:
+        - name: programId
+          in: path
+          description: Identifier of program
+          required: true
+          type: integer
+          format: int64
+        - name: environmentId
+          in: path
+          description: Identifier of environment
+          required: true
+          type: integer
+          format: int64
+        - name: x-gw-ims-org-id
+          in: header
+          description: IMS organization ID that the request is being made under.
+          required: true
+          type: string
+        - name: Authorization
+          in: header
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
+          required: true
+          type: string
+        - name: x-api-key
+          in: header
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
+          required: true
+          type: string
+      responses:
+        '200':
+          description: List of domain mappings by environment retrieved
+          schema:
+            $ref: '#/definitions/DomainMappingList'
+  /api/program/{programId}/site/{siteId}/domain-mappings:
+    get:
+      tags:
+        - Domain Mappings - CDN Configurations
+      summary: List of domain mappings by EDS site
+      description: ''
+      operationId: getAllDomainMappingsByProgramIdAndSiteId
+      parameters:
+        - name: programId
+          in: path
+          description: Identifier of program
+          required: true
+          type: integer
+          format: int64
+        - name: siteId
+          in: path
+          description: Identifier of EDS site
+          required: true
+          type: integer
+          format: int64
+        - name: x-gw-ims-org-id
+          in: header
+          description: IMS organization ID that the request is being made under.
+          required: true
+          type: string
+        - name: Authorization
+          in: header
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
+          required: true
+          type: string
+        - name: x-api-key
+          in: header
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
+          required: true
+          type: string
+      responses:
+        '200':
+          description: List of domain mappings by environment retrieved
+          schema:
+            $ref: '#/definitions/DomainMappingList'
+  /api/program/{programId}/dv-certificates:
+    post:
+      tags:
+        - SSL Certificates
+      summary: Create DV certificate
+      description: ''
+      operationId: createDvCertificate
+      parameters:
+        - name: programId
+          in: path
+          description: Identifier of the program
+          required: true
+          type: integer
+          format: int64
+        - in: body
+          name: body
+          description: Payload for creating the DV certificate
+          required: true
+          schema:
+            $ref: '#/definitions/CreateDvCertificateBody'
+        - name: x-gw-ims-org-id
+          in: header
+          description: IMS organization ID that the request is being made under.
+          required: true
+          type: string
+        - name: Authorization
+          in: header
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
+          required: true
+          type: string
+        - name: x-api-key
+          in: header
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
+          required: true
+          type: string
+        - name: Content-Type
+          in: header
+          description: Must always be application/json
+          required: true
+          type: string
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            $ref: '#/definitions/SslCertificate'
+        '201':
+          description: Created DV certificate
+          schema:
+            $ref: '#/definitions/SslCertificate'
+  /api/program/{programId}/site/{siteId}:
+    get:
+      tags:
+        - EDS Sites
+      summary: Get Site by Id
+      description: ''
+      operationId: retrieveSite
+      parameters:
+        - name: programId
+          in: path
+          required: true
+          type: string
+        - name: siteId
+          in: path
+          required: true
+          type: integer
+          format: int64
+        - name: x-gw-ims-org-id
+          in: header
+          description: IMS organization ID that the request is being made under.
+          required: true
+          type: string
+        - name: Authorization
+          in: header
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
+          required: true
+          type: string
+        - name: x-api-key
+          in: header
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Site retrieved
+          schema:
+            $ref: '#/definitions/Site'
+        '404':
+          description: Site could not be found
+    put:
+      tags:
+        - EDS Sites
+      summary: Update Site
+      description: ''
+      operationId: updateSite
+      parameters:
+        - name: programId
+          in: path
+          required: true
+          type: string
+        - name: siteId
+          in: path
+          required: true
+          type: integer
+          format: int64
+        - name: x-gw-ims-org-id
+          in: header
+          description: IMS organization ID that the request is being made under.
+          required: true
+          type: string
+        - name: Authorization
+          in: header
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
+          required: true
+          type: string
+        - name: x-api-key
+          in: header
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Site updated
+          schema:
+            $ref: '#/definitions/Site'
+        '404':
+          description: Site could not be found
+    delete:
+      tags:
+        - EDS Sites
+      summary: Delete Site
+      description: ''
+      operationId: deleteSite
+      parameters:
+        - name: programId
+          in: path
+          required: true
+          type: string
+        - name: siteId
+          in: path
+          required: true
+          type: integer
+          format: int64
+        - name: x-gw-ims-org-id
+          in: header
+          description: IMS organization ID that the request is being made under.
+          required: true
+          type: string
+        - name: Authorization
+          in: header
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
+          required: true
+          type: string
+        - name: x-api-key
+          in: header
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Site deleted
+          schema:
+            $ref: '#/definitions/Site'
+        '404':
+          description: Site could not be found
+  /api/program/{programId}/site/{siteId}/validate:
+    put:
+      tags:
+        - EDS Sites
+      summary: Validate Site
+      description: ''
+      operationId: validateSite
+      parameters:
+        - name: programId
+          in: path
+          description: Identifier of the program
+          required: true
+          type: string
+        - name: siteId
+          in: path
+          description: Identifier of the site
+          required: true
+          type: integer
+          format: int64
+        - name: x-gw-ims-org-id
+          in: header
+          description: IMS organization ID that the request is being made under.
+          required: true
+          type: string
+        - name: Authorization
+          in: header
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
+          required: true
+          type: string
+        - name: x-api-key
+          in: header
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Site validated
+          schema:
+            $ref: '#/definitions/Site'
+        '400':
+          description: Site could not be validated. CloudManager challenge does not match
+        '500':
+          description: Internal Server Error
+        '504':
+          description: Site could not be validated in time
+  /api/program/{programId}/sites:
+    get:
+      tags:
+        - EDS Sites
+      summary: Get All Sites by programId
+      description: ''
+      operationId: getProgramSites
+      parameters:
+        - name: programId
+          in: path
+          required: true
+          type: string
+        - name: x-gw-ims-org-id
+          in: header
+          description: IMS organization ID that the request is being made under.
+          required: true
+          type: string
+        - name: Authorization
+          in: header
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
+          required: true
+          type: string
+        - name: x-api-key
+          in: header
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Sites retrieved
+          schema:
+            $ref: '#/definitions/SiteList'
+    post:
+      tags:
+        - EDS Sites
+      summary: Create Site
+      description: ''
+      operationId: createSite
+      parameters:
+        - name: programId
+          in: path
+          required: true
+          type: string
+        - name: x-gw-ims-org-id
+          in: header
+          description: IMS organization ID that the request is being made under.
+          required: true
+          type: string
+        - name: Authorization
+          in: header
+          description: >-
+            Bearer [token] - An access token for the technical account created
+            through integration with Adobe IO
+          required: true
+          type: string
+        - name: x-api-key
+          in: header
+          description: >-
+            IMS Client ID (API Key) which is subscribed to consume services on
+            console.adobe.io
+          required: true
+          type: string
+      responses:
+        '201':
+          description: Site created
+          schema:
+            $ref: '#/definitions/Site'
 definitions:
   ProgramList:
     type: object
@@ -4413,7 +5912,7 @@ definitions:
         type: object
         readOnly: true
         properties:
-          'http://ns.adobe.com/adobecloud/rel/tenant':
+          http://ns.adobe.com/adobecloud/rel/tenant:
             description: The tenant this program belongs to
             $ref: '#/definitions/HalLink'
           self:
@@ -4436,7 +5935,7 @@ definitions:
         description: Name of the program
         minLength: 0
         maxLength: 64
-        pattern: '(?=.*[a-zA-Z])[-+!''"/#$%&*.,;:()’@-}À-ÿ– 0-9]*'
+        pattern: (?=.*[a-zA-Z])[-+!'"/#$%&*.,;:()’@-}À-ÿ– 0-9]*
       enabled:
         type: boolean
         description: Whether this Program has been enabled for Cloud Manager usage
@@ -4483,30 +5982,30 @@ definitions:
         type: object
         readOnly: true
         properties:
-          'http://ns.adobe.com/adobecloud/rel/pipelines':
+          http://ns.adobe.com/adobecloud/rel/pipelines:
             description: Pipelines defined in the program
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/environments':
+          http://ns.adobe.com/adobecloud/rel/environments:
             description: The environments linked to this program.
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/repositories':
+          http://ns.adobe.com/adobecloud/rel/repositories:
             description: The repositories linked to this program.
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/ipAllowlists':
+          http://ns.adobe.com/adobecloud/rel/ipAllowlists:
             description: The IP allowlists linked to this program.
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/certificates':
+          http://ns.adobe.com/adobecloud/rel/certificates:
             description: The SSL certificates linked to this program.
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/domainNames':
+          http://ns.adobe.com/adobecloud/rel/domainNames:
             description: The domain names linked to this program.
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/tenant':
+          http://ns.adobe.com/adobecloud/rel/tenant:
             description: The tenant this program belongs to
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/networkInfrastructures':
+          http://ns.adobe.com/adobecloud/rel/networkInfrastructures:
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/regions':
+          http://ns.adobe.com/adobecloud/rel/regions:
             description: The regions available for this program.
             $ref: '#/definitions/HalLink'
           self:
@@ -4566,7 +6065,10 @@ definitions:
       trigger:
         type: string
         example: MANUAL
-        description: 'How should the execution be triggered. ON_COMMIT: each time one or more commits are pushed and the Pipeline is idle then a execution is triggered. MANUAL: triggerd through UI or API.'
+        description: >-
+          How should the execution be triggered. ON_COMMIT: each time one or
+          more commits are pushed and the Pipeline is idle then a execution is
+          triggered. MANUAL: triggerd through UI or API.
         enum:
           - ON_COMMIT
           - MANUAL
@@ -4616,25 +6118,25 @@ definitions:
         type: object
         readOnly: true
         properties:
-          'http://ns.adobe.com/adobecloud/rel/program':
+          http://ns.adobe.com/adobecloud/rel/program:
             description: The Program this pipeline belongs to.
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/execution':
+          http://ns.adobe.com/adobecloud/rel/execution:
             description: Current pipeline execution if any
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/execution/id':
+          http://ns.adobe.com/adobecloud/rel/execution/id:
             description: Get pipeline execution by id
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/executions':
+          http://ns.adobe.com/adobecloud/rel/executions:
             description: Get all historic executions for this pipeline.
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/variables':
+          http://ns.adobe.com/adobecloud/rel/variables:
             description: Custom pipeline variables
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/rollbackLastSuccessfulExecution':
+          http://ns.adobe.com/adobecloud/rel/rollbackLastSuccessfulExecution:
             description: Start a CI/CD rollback execution
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/cache':
+          http://ns.adobe.com/adobecloud/rel/cache:
             description: Pipeline cache
             $ref: '#/definitions/HalLink'
           self:
@@ -4660,20 +6162,23 @@ definitions:
           - DEPLOY
       repositoryId:
         type: string
-        description: |-
-          Identifier of the source repository. The code from this repository will be build at the start of this phase. 
+        description: >-
+          Identifier of the source repository. The code from this repository
+          will be build at the start of this phase. 
+
           Mandatory if type=BUILD
       branch:
         type: string
-        description: |-
-          Name of the tracked branch or a fully qualified git tag (e.g. refs/tags/v1). 
+        description: >-
+          Name of the tracked branch or a fully qualified git tag (e.g.
+          refs/tags/v1). 
            Assumed to be `master` if missing.
       environmentId:
         type: string
         description: Identifier of the target environment. Mandatory if type=DEPLOY
       environmentType:
         type: string
-        description: 'Type of environment (for example stage or prod, readOnly = true)'
+        description: Type of environment (for example stage or prod, readOnly = true)
         enum:
           - dev
           - stage
@@ -4683,7 +6188,9 @@ definitions:
           - devxl
       steps:
         type: array
-        description: 'Steps to be included in the phase in execution order. Might be added or not, depending on permissions or configuration'
+        description: >-
+          Steps to be included in the phase in execution order. Might be added
+          or not, depending on permissions or configuration
         items:
           $ref: '#/definitions/PipelineStep'
     description: Describes a phase of a pipeline
@@ -4764,7 +6271,9 @@ definitions:
           - PUSH_UPGRADES
       pipelineExecutionMode:
         type: string
-        description: The mode in which the execution occurred. EMERGENCY mode will skip certain steps and is only available to select AMS customers
+        description: >-
+          The mode in which the execution occurred. EMERGENCY mode will skip
+          certain steps and is only available to select AMS customers
         enum:
           - NORMAL
           - EMERGENCY
@@ -4799,10 +6308,10 @@ definitions:
         type: object
         readOnly: true
         properties:
-          'http://ns.adobe.com/adobecloud/rel/program':
+          http://ns.adobe.com/adobecloud/rel/program:
             description: Get the program of the execution
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/pipeline':
+          http://ns.adobe.com/adobecloud/rel/pipeline:
             description: Get the pipeline of the execution
             $ref: '#/definitions/HalLink'
           self:
@@ -4871,30 +6380,37 @@ definitions:
         type: object
         readOnly: true
         properties:
-          'http://ns.adobe.com/adobecloud/rel/execution':
+          http://ns.adobe.com/adobecloud/rel/execution:
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/pipeline':
+          http://ns.adobe.com/adobecloud/rel/pipeline:
             description: Get the pipeline of the execution
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/pipeline/logs':
+          http://ns.adobe.com/adobecloud/rel/pipeline/logs:
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/pipeline/metrics':
+          http://ns.adobe.com/adobecloud/rel/pipeline/metrics:
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/pipeline/reExecute':
+          http://ns.adobe.com/adobecloud/rel/pipeline/reExecute:
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/pipeline/advance':
-            description: 'Post to this link in order to advance the pipeline, if paused and waiting for user interaction. Link is present in output only in that case.'
+          http://ns.adobe.com/adobecloud/rel/pipeline/advance:
+            description: >-
+              Post to this link in order to advance the pipeline, if paused and
+              waiting for user interaction. Link is present in output only in
+              that case.
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/pipeline/cancel':
-            description: Post to this link in order to cancel the pipeline. Link is present in output only in that case.
+          http://ns.adobe.com/adobecloud/rel/pipeline/cancel:
+            description: >-
+              Post to this link in order to cancel the pipeline. Link is present
+              in output only in that case.
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/program':
+          http://ns.adobe.com/adobecloud/rel/program:
             description: Get the program of the execution
             $ref: '#/definitions/HalLink'
           self:
             $ref: '#/definitions/HalLink'
             description: This object's representation
-    description: Describes the status of a particular pipeline execution step for display purposes
+    description: >-
+      Describes the status of a particular pipeline execution step for display
+      purposes
   PipelineExecutionListRepresentation:
     type: object
     properties:
@@ -5022,7 +6538,7 @@ definitions:
         type: string
         example: AcmeCorp Dev1 Environment
         description: Name of the environment
-        pattern: '(?=.*[a-zA-Z])[-+!''"/#$%&*.,;()@-} 0-9]*'
+        pattern: (?=.*[a-zA-Z])[-+!'"/#$%&*.,;()@-} 0-9]*
       description:
         type: string
         example: This is our primary development environment
@@ -5070,30 +6586,30 @@ definitions:
         type: object
         readOnly: true
         properties:
-          'http://ns.adobe.com/adobecloud/rel/program':
+          http://ns.adobe.com/adobecloud/rel/program:
             description: The Program this environment belongs to.
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/pipeline':
-            description: 'The Pipeline this environment is assigned to, if any'
+          http://ns.adobe.com/adobecloud/rel/pipeline:
+            description: The Pipeline this environment is assigned to, if any
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/author':
+          http://ns.adobe.com/adobecloud/rel/author:
             description: Author URL
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/publish':
+          http://ns.adobe.com/adobecloud/rel/publish:
             description: Publish URL
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/preview':
+          http://ns.adobe.com/adobecloud/rel/preview:
             description: Publish URL
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/developerConsole':
+          http://ns.adobe.com/adobecloud/rel/developerConsole:
             description: Developer Console URL
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/logs':
+          http://ns.adobe.com/adobecloud/rel/logs:
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/variables':
+          http://ns.adobe.com/adobecloud/rel/variables:
             description: Custom environment variables
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/advancedNetworking':
+          http://ns.adobe.com/adobecloud/rel/advancedNetworking:
             $ref: '#/definitions/HalLink'
           self:
             $ref: '#/definitions/HalLink'
@@ -5112,16 +6628,16 @@ definitions:
         description: description
       repositoryUrl:
         type: string
-        example: 'https://git.cloudmanager.adobe.com/weretailprod/we-retail-global'
+        example: https://git.cloudmanager.adobe.com/weretailprod/we-retail-global
         description: Repository Url.
       _links:
         type: object
         readOnly: true
         properties:
-          'http://ns.adobe.com/adobecloud/rel/program':
+          http://ns.adobe.com/adobecloud/rel/program:
             description: The Program the repository belongs to
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/branches':
+          http://ns.adobe.com/adobecloud/rel/branches:
             description: List of branches in this repository
             $ref: '#/definitions/HalLink'
           self:
@@ -5182,10 +6698,10 @@ definitions:
         type: object
         readOnly: true
         properties:
-          'http://ns.adobe.com/adobecloud/rel/program':
+          http://ns.adobe.com/adobecloud/rel/program:
             description: Program
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/repository':
+          http://ns.adobe.com/adobecloud/rel/repository:
             description: Repository
             $ref: '#/definitions/HalLink'
     description: Represents a Git Branch
@@ -5277,7 +6793,7 @@ definitions:
         description: HTTP status code of the response.
       type:
         type: string
-        example: 'http://ns.adobe.com/adobecloud/error'
+        example: http://ns.adobe.com/adobecloud/error
         description: Error type identifier.
       title:
         type: string
@@ -5320,10 +6836,10 @@ definitions:
         type: object
         readOnly: true
         properties:
-          'http://ns.adobe.com/adobecloud/rel/logs/download':
+          http://ns.adobe.com/adobecloud/rel/logs/download:
             description: Download Logs link
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/logs/tail':
+          http://ns.adobe.com/adobecloud/rel/logs/tail:
             description: Tail Log link
             $ref: '#/definitions/HalLink'
     description: Log from Environment
@@ -5351,7 +6867,7 @@ definitions:
         type: object
         readOnly: true
         properties:
-          'http://ns.adobe.com/adobecloud/rel/program':
+          http://ns.adobe.com/adobecloud/rel/program:
             description: The Application this environment belongs to.
             $ref: '#/definitions/HalLink'
           self:
@@ -5373,27 +6889,38 @@ definitions:
       name:
         type: string
         example: MY_VAR1
-        description: 'Name of the variable. Can only consist of a-z, A-Z, _ and 0-9 and cannot begin with a number.'
+        description: >-
+          Name of the variable. Can only consist of a-z, A-Z, _ and 0-9 and
+          cannot begin with a number.
         minLength: 2
         maxLength: 100
         pattern: '[a-zA-Z_][a-zA-Z_0-9]*'
       value:
         type: string
         example: myValue
-        description: 'Value of the variable. Read-Write for non-secrets, write-only for secrets. The length of `secretString` values must be less than 500 characters. An empty value causes a variable to be deleted.'
+        description: >-
+          Value of the variable. Read-Write for non-secrets, write-only for
+          secrets. The length of `secretString` values must be less than 500
+          characters. An empty value causes a variable to be deleted.
         minLength: 0
         maxLength: 2048
       type:
         type: string
         example: string
-        description: Type of the variable. Default `string` if missing. `secretString` variables are encrypted at rest. The type of a variable be changed after creation; the variable must be deleted and recreated.
+        description: >-
+          Type of the variable. Default `string` if missing. `secretString`
+          variables are encrypted at rest. The type of a variable be changed
+          after creation; the variable must be deleted and recreated.
         enum:
           - string
           - secretString
       service:
         type: string
         example: author
-        description: 'Service of the variable. When not provided, the variable applies to all services. Currently the values ''author'', ''publish'', and ''preview'' are supported. Note - this value is case-sensitive.'
+        description: >-
+          Service of the variable. When not provided, the variable applies to
+          all services. Currently the values 'author', 'publish', and 'preview'
+          are supported. Note - this value is case-sensitive.
       status:
         type: string
         example: ready
@@ -5421,7 +6948,11 @@ definitions:
         properties:
           variables:
             type: array
-            example: '[{ ''name'':''variable1Name'', ''value'':''variable1Value''}, { ''name'':''variable1Name'', ''value'':''variable1Value'', ''service'':''author''}, { ''name'':''variable2Name'', ''type'':''secretString'', ''value'':''variable2SecretValue''}]'
+            example: >-
+              [{ 'name':'variable1Name', 'value':'variable1Value'}, {
+              'name':'variable1Name', 'value':'variable1Value',
+              'service':'author'}, { 'name':'variable2Name',
+              'type':'secretString', 'value':'variable2SecretValue'}]
             description: Variables set on environment
             items:
               $ref: '#/definitions/Variable'
@@ -5429,18 +6960,21 @@ definitions:
         type: object
         readOnly: true
         properties:
-          'http://ns.adobe.com/adobecloud/rel/environment':
+          http://ns.adobe.com/adobecloud/rel/environment:
             description: The environment holding the variables
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/pipeline':
+          http://ns.adobe.com/adobecloud/rel/pipeline:
             description: The pipeline holding the variables
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/program':
+          http://ns.adobe.com/adobecloud/rel/program:
             description: The Program
             $ref: '#/definitions/HalLink'
           self:
             $ref: '#/definitions/HalLink'
             description: This object's representation
+          http://ns.adobe.com/adobecloud/rel/edgeEnvironment:
+            description: The edge environment holding the variables
+            $ref: '#/definitions/HalLink'
   RegionDeployment:
     type: object
     properties:
@@ -5498,20 +7032,28 @@ definitions:
         type: object
         readOnly: true
         properties:
-          'http://ns.adobe.com/adobecloud/rel/flow':
+          http://ns.adobe.com/adobecloud/rel/flow:
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/kubernetesCluster':
+          http://ns.adobe.com/adobecloud/rel/kubernetesCluster:
             description: Get the Kubernetes Cluster in which this deployment happens
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/kubernetesNamespace':
+          http://ns.adobe.com/adobecloud/rel/kubernetesNamespace:
             description: Get the Kubernetes Namespace in which this deployment happens
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/region':
+          http://ns.adobe.com/adobecloud/rel/region:
             description: Region being used for this deployment
             $ref: '#/definitions/HalLink'
           self:
             $ref: '#/definitions/HalLink'
             description: This object's representation
+      regionName:
+        type: string
+      clusterName:
+        type: string
+      namespaceName:
+        type: string
+      dataStore:
+        $ref: '#/definitions/DataStore'
     description: describes region deployments for an environment
   RegionDeploymentList:
     type: object
@@ -5575,7 +7117,7 @@ definitions:
         type: object
         readOnly: true
         properties:
-          'http://ns.adobe.com/adobecloud/rel/program':
+          http://ns.adobe.com/adobecloud/rel/program:
             description: The Application this content set belongs to.
             $ref: '#/definitions/HalLink'
           self:
@@ -5653,7 +7195,7 @@ definitions:
         description: Destination environment name
       tier:
         type: string
-        description: 'The tier, for example author'
+        description: The tier, for example author
       status:
         type: string
         description: Status of the flows
@@ -5667,16 +7209,16 @@ definitions:
         type: object
         readOnly: true
         properties:
-          'http://ns.adobe.com/adobecloud/rel/contentSet':
+          http://ns.adobe.com/adobecloud/rel/contentSet:
             description: The Content set for this flow.
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/program':
+          http://ns.adobe.com/adobecloud/rel/program:
             description: The Application this content set belongs to.
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/environment':
+          http://ns.adobe.com/adobecloud/rel/environment:
             description: The source Environment this content flow is copying from.
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/destEnvironment':
+          http://ns.adobe.com/adobecloud/rel/destEnvironment:
             description: The destination Environment this content flow is copying to.
             $ref: '#/definitions/HalLink'
           self:
@@ -5935,7 +7477,7 @@ definitions:
         type: object
         readOnly: true
         properties:
-          'http://ns.adobe.com/adobecloud/rel/atlascluster':
+          http://ns.adobe.com/adobecloud/rel/atlascluster:
             $ref: '#/definitions/HalLink'
   RestorePointsList:
     type: object
@@ -6010,11 +7552,11 @@ definitions:
       programId:
         type: string
         example: '14'
-        description: 'Identifier of the program, unique within the space'
+        description: Identifier of the program, unique within the space
       environmentId:
         type: string
         example: '14'
-        description: 'Identifier of the environment, unique within the space'
+        description: Identifier of the environment, unique within the space
       status:
         type: string
         example: not_started
@@ -6026,7 +7568,7 @@ definitions:
           - error
           - failed
       errorDetails:
-        description: 'Error details, present only when execution failed'
+        description: Error details, present only when execution failed
         $ref: '#/definitions/ErrorDetailsRepresentation'
       environmentDetailsAtSnapshotDate:
         description: Environment details at snapshot timestamp
@@ -6046,14 +7588,14 @@ definitions:
         type: object
         readOnly: true
         properties:
-          'http://ns.adobe.com/adobecloud/rel/environment':
+          http://ns.adobe.com/adobecloud/rel/environment:
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/flow':
+          http://ns.adobe.com/adobecloud/rel/flow:
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/program':
+          http://ns.adobe.com/adobecloud/rel/program:
             description: The Application this environment belongs to
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/restoreExecution/logs/download':
+          http://ns.adobe.com/adobecloud/rel/restoreExecution/logs/download:
             $ref: '#/definitions/HalLink'
           self:
             $ref: '#/definitions/HalLink'
@@ -6123,7 +7665,7 @@ definitions:
       pointInTimeInMillis:
         type: string
         description: Desired point in time
-        pattern: '\d{1,19}$'
+        pattern: \d{1,19}$
   IPAllowedListBinding:
     type: object
     required:
@@ -6133,6 +7675,7 @@ definitions:
         type: string
         example: '14'
         description: Identifier of the IP Allowed List Binding to an Environment
+        format: int64
       tier:
         type: string
         example: publish
@@ -6142,6 +7685,7 @@ definitions:
           - publish
           - preview
           - delivery
+          - DELIVERY
       status:
         type: string
         example: NOT_STARTED
@@ -6158,22 +7702,25 @@ definitions:
         type: string
         example: '22'
         description: Identifier of the program.
+        format: int64
       ipAllowListId:
         type: string
         example: '17'
         description: Identifier of the IP allow list.
+        format: int64
       environmentId:
         type: string
         example: '5'
         description: Identifier of the environment.
+        format: int64
       _links:
         type: object
         readOnly: true
         properties:
-          'http://ns.adobe.com/adobecloud/rel/program':
+          http://ns.adobe.com/adobecloud/rel/program:
             description: The Application this environment belongs to.
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/ipAllowList':
+          http://ns.adobe.com/adobecloud/rel/ipAllowList:
             description: IpAllowList to be binded to the environment.
             $ref: '#/definitions/HalLink'
           self:
@@ -6190,6 +7737,7 @@ definitions:
         type: string
         example: '14'
         description: Identifier of the IP Allowed List
+        format: int64
       name:
         type: string
         example: NewYork Office
@@ -6209,6 +7757,7 @@ definitions:
         type: string
         example: '22'
         description: Identifier of the program.
+        format: int64
       bindings:
         type: array
         description: IP Allowlist bindings
@@ -6218,9 +7767,9 @@ definitions:
         type: object
         readOnly: true
         properties:
-          'http://ns.adobe.com/adobecloud/rel/ipAllowlistBindings':
+          http://ns.adobe.com/adobecloud/rel/ipAllowlistBindings:
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/program':
+          http://ns.adobe.com/adobecloud/rel/program:
             description: The Application this environment belongs to.
             $ref: '#/definitions/HalLink'
           self:
@@ -6255,6 +7804,8 @@ definitions:
           self:
             $ref: '#/definitions/HalLink'
             description: This object's representation
+      ipAllowlistId:
+        type: string
   IPAllowlistList:
     type: object
     properties:
@@ -6379,19 +7930,19 @@ definitions:
         type: object
         readOnly: true
         properties:
-          'http://ns.adobe.com/adobecloud/rel/domainName/certificates':
+          http://ns.adobe.com/adobecloud/rel/domainName/certificates:
             description: SSL certificates in program
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/domainName/deploy':
+          http://ns.adobe.com/adobecloud/rel/domainName/deploy:
             description: Trigger DNS TXT record verification and start CDN deployment
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/domainName/verify':
+          http://ns.adobe.com/adobecloud/rel/domainName/verify:
             description: Trigger DNS route verification of the domain name
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/environment':
+          http://ns.adobe.com/adobecloud/rel/environment:
             description: The environment holding the domain name
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/program':
+          http://ns.adobe.com/adobecloud/rel/program:
             description: The Application this domain name belongs to.
             $ref: '#/definitions/HalLink'
           self:
@@ -6438,10 +7989,12 @@ definitions:
       id:
         type: string
         description: id
+        format: int64
       programId:
         type: string
         example: '14'
         description: Identifier of the application. Unique within the space.
+        format: int64
       serialNumber:
         type: string
         description: Unique identifier of the certificate at CA level.
@@ -6489,6 +8042,36 @@ definitions:
           self:
             $ref: '#/definitions/HalLink'
             description: This object's representation
+      sslCertificateType:
+        type: string
+        enum:
+          - DV
+          - EV
+          - OV
+      certificate:
+        type: string
+      privateKeyPath:
+        type: string
+      commonNameRegex:
+        type: string
+      subjectAlternativeNamesRegex:
+        type: array
+        items:
+          type: string
+      chain:
+        type: string
+      deletedAt:
+        type: integer
+        format: int64
+      externalId:
+        type: integer
+        format: int64
+      sslCertificateStatus:
+        type: string
+        enum:
+          - PENDING
+          - VALID
+          - EXPIRED
     description: Describes an SSL Certificate
   CertificatesList:
     type: object
@@ -6562,7 +8145,9 @@ definitions:
       applicationId:
         type: string
         example: '44'
-        description: The id of the Cloud Manager application this sub account user list is linked to
+        description: >-
+          The id of the Cloud Manager application this sub account user list is
+          linked to
       _embedded:
         type: object
         readOnly: true
@@ -6575,11 +8160,13 @@ definitions:
         type: object
         readOnly: true
         properties:
-          'http://ns.adobe.com/adobecloud/rel/application':
+          http://ns.adobe.com/adobecloud/rel/application:
             description: Application linked to this New Relic sub account
             $ref: '#/definitions/HalLink'
-          'http://ns.adobe.com/adobecloud/rel/newRelicSubAccount':
-            description: New Relic sub account linked to the New Relic sub account User list
+          http://ns.adobe.com/adobecloud/rel/newRelicSubAccount:
+            description: >-
+              New Relic sub account linked to the New Relic sub account User
+              list
             $ref: '#/definitions/HalLink'
           self:
             $ref: '#/definitions/HalLink'
@@ -6647,7 +8234,7 @@ definitions:
         type: object
         readOnly: true
         properties:
-          'http://ns.adobe.com/adobecloud/rel/programs':
+          http://ns.adobe.com/adobecloud/rel/programs:
             description: Programs defined in the tenant
             $ref: '#/definitions/HalLink'
           self:
@@ -6833,7 +8420,7 @@ definitions:
       saLifetime:
         type: integer
         format: int32
-        description: 'QM SA Lifetime in Seconds, minimum 300'
+        description: QM SA Lifetime in Seconds, minimum 300
         minimum: 300
   VpnConnection:
     type: object
@@ -6893,10 +8480,15 @@ definitions:
       region:
         type: string
         example: va6
-        description: 'Region to create the infrastructure. Use your primary region, whose identifier can be retrieved from the [List Regions endpoint](#operation/getProgramRegions).'
+        description: >-
+          Region to create the infrastructure. Use your primary region, whose
+          identifier can be retrieved from the [List Regions
+          endpoint](#operation/getProgramRegions).
       isPrimaryRegion:
         type: boolean
-        description: Boolean property to mark whether network infrastructure being created is for primary region or not.
+        description: >-
+          Boolean property to mark whether network infrastructure being created
+          is for primary region or not.
         default: false
       created:
         type: string
@@ -6910,7 +8502,10 @@ definitions:
         readOnly: true
       addressSpace:
         type: array
-        description: A list of CIDRs. It can only be one /26 CIDR (64 IP addresses) or bigger IP range in the customer space. Cannot be changed later. Only applicable to VPN.
+        description: >-
+          A list of CIDRs. It can only be one /26 CIDR (64 IP addresses) or
+          bigger IP range in the customer space. Cannot be changed later. Only
+          applicable to VPN.
         items:
           type: string
       dns:
@@ -6929,7 +8524,7 @@ definitions:
         type: object
         readOnly: true
         properties:
-          'http://ns.adobe.com/adobecloud/rel/program':
+          http://ns.adobe.com/adobecloud/rel/program:
             $ref: '#/definitions/HalLink'
           self:
             $ref: '#/definitions/HalLink'
@@ -6973,7 +8568,7 @@ definitions:
         type: string
         example: smtp.example.com
         description: Destination host
-        pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?([.][a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?([.][a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
       portDest:
         type: integer
         format: int32
@@ -7006,7 +8601,10 @@ definitions:
         readOnly: true
       nonProxyHosts:
         type: array
-        description: 'A list of hosts that should be reached directly, bypassing the special VPN or egress routing. The patterns may start or end with a ''''*'''' for wildcards.'
+        description: >-
+          A list of hosts that should be reached directly, bypassing the special
+          VPN or egress routing. The patterns may start or end with a ''*'' for
+          wildcards.
         items:
           type: string
         example:
@@ -7307,52 +8905,71 @@ definitions:
       name:
         type: string
         example: MY_VAR1
-        description: 'Name of the variable. Can only consist of a-z, A-Z, _ and 0-9 and cannot begin with a number.'
+        description: >-
+          Name of the variable. Can only consist of a-z, A-Z, _ and 0-9 and
+          cannot begin with a number.
         minLength: 2
         maxLength: 100
         pattern: '[a-zA-Z_][a-zA-Z_0-9]*'
       value:
         type: string
         example: myValue
-        description: 'Value of the variable. Read-Write for non-secrets, write-only for secrets. The length of `secretString` values must be less than 500 characters. An empty value causes a variable to be deleted.'
+        description: >-
+          Value of the variable. Read-Write for non-secrets, write-only for
+          secrets. The length of `secretString` values must be less than 500
+          characters. An empty value causes a variable to be deleted.
         minLength: 0
         maxLength: 2048
       type:
         type: string
         example: string
-        description: Type of the variable. Default `string` if missing. `secretString` variables are encrypted at rest. The type of a variable be changed after creation; the variable must be deleted and recreated.
+        description: >-
+          Type of the variable. Default `string` if missing. `secretString`
+          variables are encrypted at rest. The type of a variable be changed
+          after creation; the variable must be deleted and recreated.
         enum:
           - string
           - secretString
       service:
         type: string
         example: author
-        description: 'Service of the variable. When not provided, the variable applies to all services. Currently the values ''author'', ''publish'', and ''preview'' are supported. Note - this value is case-sensitive.'
-    description: 'A change (create, update, delete) of a named value on an Environment'
+        description: >-
+          Service of the variable. When not provided, the variable applies to
+          all services. Currently the values 'author', 'publish', and 'preview'
+          are supported. Note - this value is case-sensitive.
+    description: A change (create, update, delete) of a named value on an Environment
   PipelineVariableUpdate:
     type: object
     properties:
       name:
         type: string
         example: MY_VAR1
-        description: 'Name of the variable. Can only consist of a-z, A-Z, _ and 0-9 and cannot begin with a number.'
+        description: >-
+          Name of the variable. Can only consist of a-z, A-Z, _ and 0-9 and
+          cannot begin with a number.
         minLength: 2
         maxLength: 100
         pattern: '[a-zA-Z_][a-zA-Z_0-9]*'
       value:
         type: string
         example: myValue
-        description: 'Value of the variable. Read-Write for non-secrets, write-only for secrets. The length of `secretString` values must be less than 500 characters. An empty value causes a variable to be deleted.'
+        description: >-
+          Value of the variable. Read-Write for non-secrets, write-only for
+          secrets. The length of `secretString` values must be less than 500
+          characters. An empty value causes a variable to be deleted.
         minLength: 0
         maxLength: 2048
       type:
         type: string
         example: string
-        description: Type of the variable. Default `string` if missing. `secretString` variables are encrypted at rest. The type of a variable be changed after creation; the variable must be deleted and recreated.
+        description: >-
+          Type of the variable. Default `string` if missing. `secretString`
+          variables are encrypted at rest. The type of a variable be changed
+          after creation; the variable must be deleted and recreated.
         enum:
           - string
           - secretString
-    description: 'A change (create, update, delete) of a named value on a Pipeline'
+    description: A change (create, update, delete) of a named value on a Pipeline
   PipelinePhaseUpdate:
     type: object
     required:
@@ -7372,10 +8989,16 @@ definitions:
           - DEPLOY
       repositoryId:
         type: string
-        description: 'For BUILD phase type. Identifier of the source repository. The code from this repository will be build at the start of this phase. If not provided, the current value is retained.'
+        description: >-
+          For BUILD phase type. Identifier of the source repository. The code
+          from this repository will be build at the start of this phase. If not
+          provided, the current value is retained.
       branch:
         type: string
-        description: 'For BUILD phase type. Name of the tracked branch or a fully qualified git tag (e.g. refs/tags/v1). If not provided, the current value is retained.'
+        description: >-
+          For BUILD phase type. Name of the tracked branch or a fully qualified
+          git tag (e.g. refs/tags/v1). If not provided, the current value is
+          retained.
       environmentId:
         type: string
         description: For DEPLOY phase type. Identifier of the target environment.
@@ -7405,18 +9028,25 @@ definitions:
         type: array
         items:
           type: string
-        description: 'For deploy steps on AMS pipelines, list of paths to invalidate on dispatchers after package installation.'
+        description: >-
+          For deploy steps on AMS pipelines, list of paths to invalidate on
+          dispatchers after package installation.
       dispatcherCacheFlushPaths:
         type: array
         items:
           type: string
-        description: 'For deploy steps on AMS pipelines, list of paths to flush on dispatchers after package installation.'
+        description: >-
+          For deploy steps on AMS pipelines, list of paths to flush on
+          dispatchers after package installation.
   EnableAdvancedNetworkingConfiguration:
     type: object
     properties:
       nonProxyHosts:
         type: array
-        description: 'A list of hosts that should be reached directly, bypassing the special VPN or egress routing. The patterns may start or end with a ''''*'''' for wildcards.'
+        description: >-
+          A list of hosts that should be reached directly, bypassing the special
+          VPN or egress routing. The patterns may start or end with a ''*'' for
+          wildcards.
         items:
           type: string
         example:
@@ -7429,17 +9059,23 @@ definitions:
           $ref: '#/definitions/PortForwardRepresentation'
   PipelineExecutionStepStateDetails:
     type: object
-    description: Details available for each step state. The set of properties available will vary by the step action.
+    description: >-
+      Details available for each step state. The set of properties available
+      will vary by the step action.
     properties:
       deployCommands:
         type: string
-        description: 'For deploy steps, a JSON array encoded as a string which lists the deployment activities expected to be performed.'
+        description: >-
+          For deploy steps, a JSON array encoded as a string which lists the
+          deployment activities expected to be performed.
       currentDeployCommandId:
         type: string
-        description: 'For deploy steps, the current identifier from the deployCommands which is being executed.'
+        description: >-
+          For deploy steps, the current identifier from the deployCommands which
+          is being executed.
       environmentUrls:
         type: array
-        description: 'For deploy steps, the the set of URLs for the environment.'
+        description: For deploy steps, the the set of URLs for the environment.
         items:
           type: object
           properties:
@@ -7449,53 +9085,76 @@ definitions:
               type: string
       deploymentStepDescription:
         type: string
-        description: 'For deploy steps, a JSON array encoded as a string which includes the detailed list of deployment activities which have been performed.'
+        description: >-
+          For deploy steps, a JSON array encoded as a string which includes the
+          detailed list of deployment activities which have been performed.
       input:
         type: object
-        description: 'Input provided when advancing the step. See documentation at https://www.adobe.io/experience-cloud/cloud-manager/guides/api-usage/advancing-and-cancelling-steps/ for details.'
+        description: >-
+          Input provided when advancing the step. See documentation at
+          https://www.adobe.io/experience-cloud/cloud-manager/guides/api-usage/advancing-and-cancelling-steps/
+          for details.
   PipelineStepOptions:
     type: object
     description: Options for a pipeline step. Will vary based on step action and platform.
     properties:
       skipDetachingDispatchers:
         type: boolean
-        description: 'For deploy steps on AMS pipelines, if true will not detach dispatcher from the load balancer.'
+        description: >-
+          For deploy steps on AMS pipelines, if true will not detach dispatcher
+          from the load balancer.
       dispatcherCacheInvalidationPaths:
         type: array
         items:
           type: string
-        description: 'For deploy steps on AMS pipelines, list of paths to invalidate on dispatchers after package installation.'
+        description: >-
+          For deploy steps on AMS pipelines, list of paths to invalidate on
+          dispatchers after package installation.
       dispatcherCacheFlushPaths:
         type: array
         items:
           type: string
-        description: 'For deploy steps on AMS pipelines, list of paths to flush on dispatchers after package installation.'
+        description: >-
+          For deploy steps on AMS pipelines, list of paths to flush on
+          dispatchers after package installation.
       cse:
         type: string
         enum:
           - MY_CSE
           - ANY_CSE
-        description: 'For managed steps on AMS pipelines, which CSE will be responsible for CSE oversight.'
+        description: >-
+          For managed steps on AMS pipelines, which CSE will be responsible for
+          CSE oversight.
       popularPagesWeight:
         type: integer
         format: int32
-        description: 'For loadTest steps on AMS pipelines, the percentage of performance test traffic which will be sent to the popular pages bucket.'
+        description: >-
+          For loadTest steps on AMS pipelines, the percentage of performance
+          test traffic which will be sent to the popular pages bucket.
       newPagesWeight:
         type: integer
         format: int32
-        description: 'For loadTest steps on AMS pipelines, the percentage of performance test traffic which will be sent to the new pages bucket.'
+        description: >-
+          For loadTest steps on AMS pipelines, the percentage of performance
+          test traffic which will be sent to the new pages bucket.
       otherPagesWeight:
         type: integer
         format: int32
-        description: 'For loadTest steps on AMS pipelines, the percentage of performance test traffic which will be sent to the other pages bucket.'
+        description: >-
+          For loadTest steps on AMS pipelines, the percentage of performance
+          test traffic which will be sent to the other pages bucket.
       imageAssetsWeight:
         type: integer
         format: int32
-        description: 'For assetsTest steps on AMS pipelines, the percentage of asset uploads which will be test images.'
+        description: >-
+          For assetsTest steps on AMS pipelines, the percentage of asset uploads
+          which will be test images.
       pdfAssetsWeight:
         type: integer
         format: int32
-        description: 'For assetsTest steps on AMS pipelines, the percentage of asset uploads which will be test PDF files.'
+        description: >-
+          For assetsTest steps on AMS pipelines, the percentage of asset uploads
+          which will be test PDF files.
   NewProgram:
     type: object
     required:
@@ -7621,11 +9280,15 @@ definitions:
       dnsTxtRecord:
         type: string
         example: adobe-aem-verification=www.adobe.com/1/2/ab-cd-ef
-        description: DNS TXT record. Must match the corresponding record returned from the validate request.
+        description: >-
+          DNS TXT record. Must match the corresponding record returned from the
+          validate request.
       dnsZone:
         type: string
         example: adobe.com.
-        description: Name of the DNS zone. Must match the corresponding value returned from the validate request.
+        description: >-
+          Name of the DNS zone. Must match the corresponding value returned from
+          the validate request.
   NewRelicSubAccountUser:
     type: object
     properties:
@@ -7678,3 +9341,501 @@ definitions:
       logs/tail:
         $ref: '#/definitions/Redirect'
         description: link to download tails log
+  DataStore:
+    type: object
+    properties:
+      type:
+        type: string
+      blobStorageAccountName:
+        type: string
+      blobContainerName:
+        type: string
+  Updateanipallowlist:
+    type: object
+    required:
+      - ipCidrSet
+      - name
+    properties:
+      name:
+        type: string
+        example: NewYork Office
+        description: Name of the IP Allowed List
+      ipCidrSet:
+        type: array
+        example: '["11.22.33.44/28", "99.88.77.66/32"]'
+        description: IP CIDR Set
+        uniqueItems: true
+        items:
+          type: string
+        maxItems: 50
+        minItems: 1
+  Createanewipallowlist:
+    type: object
+    required:
+      - ipCidrSet
+      - name
+    properties:
+      name:
+        type: string
+        example: NewYork Office
+        description: Name of the IP Allowed List
+      ipCidrSet:
+        type: array
+        example: '["11.22.33.44/28", "99.88.77.66/32"]'
+        description: IP CIDR Set
+        uniqueItems: true
+        items:
+          type: string
+        maxItems: 50
+        minItems: 1
+  Domain:
+    type: object
+    required:
+      - label
+      - programId
+    properties:
+      deleted:
+        type: boolean
+        default: false
+      id:
+        type: integer
+        format: int64
+        description: id
+      domainName:
+        type: string
+        example: customer.domain.com
+        description: Name of the domain name
+      label:
+        type: string
+        description: Domain label
+      programId:
+        type: integer
+        format: int64
+        description: Id of the program
+      createdAt:
+        type: integer
+        format: int64
+        description: Create date
+      updatedAt:
+        type: integer
+        format: int64
+        description: Last updated date
+      deletedAt:
+        type: integer
+        format: int64
+        description: Deleted At
+      acmeValidationStatus:
+        type: string
+        example: NOT_VERIFIED
+        description: Acme Validation Status
+      adobeValidationStatus:
+        type: string
+        example: NOT_VERIFIED
+        description: Adobe Validation Status
+      acmeValidationToken:
+        type: string
+        description: Acme Validation Token
+      adobeValidationToken:
+        type: string
+        description: Adobe Validation Token
+    description: A Domain representation
+  UpdateaDomain'snameorlabel:
+    type: object
+    required:
+      - label
+    properties:
+      label:
+        type: string
+        example: '???'
+        description: Domain label
+  Response:
+    type: object
+    properties:
+      status:
+        type: integer
+        format: int32
+      entity:
+        type: object
+      metadata:
+        type: object
+        additionalProperties:
+          type: array
+          items:
+            type: object
+  DomainCreate:
+    type: object
+    properties:
+      domainName:
+        type: string
+        example: customer.domain.com
+        description: Name of the domain name
+    description: A Domain representation for creating a domain
+  DomainTokenValidationBody:
+    type: object
+    properties:
+      validationType:
+        type: string
+        example: acme
+        description: Type of the validation
+    description: The json body for token validation
+  DomainMapping:
+    type: object
+    properties:
+      domainMappingId:
+        type: integer
+        format: int64
+        description: Domain Mapping ID
+      programId:
+        type: integer
+        format: int64
+        description: Identifier of the CM Program
+      originId:
+        type: integer
+        format: int64
+        description: Id of either EDS site or Skyline Environment
+      domainMappingStatus:
+        type: string
+        description: Status of the domain mapping
+      domainName:
+        type: string
+        description: Name of the domain
+      originType:
+        type: string
+        description: 'Type of origin: EDS_SITE or SKYLINE_ENVIRONMENT'
+      tier:
+        type: string
+        description: 'Type of tier: PREVIEW or PUBLISH'
+        enum:
+          - PUBLISH
+          - PREVIEW
+          - AUTHOR
+          - STATIC
+          - DELIVERY
+      domainId:
+        type: integer
+        format: int64
+        description: Id of the domain
+      certificateId:
+        type: integer
+        format: int64
+        description: Id of the certificate
+      createdAt:
+        type: integer
+        format: int64
+        description: Creation date
+      updatedAt:
+        type: integer
+        format: int64
+        description: Last modification date
+      deletedAt:
+        type: integer
+        format: int64
+        description: Deletion date
+    description: Describes a domain mapping
+  Updateadomainmapping:
+    type: object
+    required:
+      - certificateId
+      - tier
+    properties:
+      certificateId:
+        type: integer
+        format: int64
+        description: Certificate ID
+      tier:
+        type: string
+        description: 'Type of tier: PREVIEW or PUBLISH'
+        enum:
+          - PUBLISH
+          - PREVIEW
+          - AUTHOR
+          - STATIC
+          - DELIVERY
+  DomainMappingList:
+    type: object
+    properties:
+      totalNumberOfItems:
+        type: integer
+        format: int32
+      domainMappings:
+        type: array
+        items:
+          $ref: '#/definitions/DomainMapping'
+  Createanewdomainmapping:
+    type: object
+    required:
+      - certificateId
+      - domainId
+      - originId
+      - originType
+      - tier
+    properties:
+      originId:
+        type: integer
+        format: int64
+        description: 'Origin ID: EDS or Skyline Environment ID'
+      domainId:
+        type: integer
+        format: int64
+        description: Domain ID
+      certificateId:
+        type: integer
+        format: int64
+        description: Certificate ID
+      tier:
+        type: string
+        description: 'Type of the tier: PREVIEW or PUBLISH'
+        enum:
+          - PUBLISH
+          - PREVIEW
+          - AUTHOR
+          - STATIC
+          - DELIVERY
+      originType:
+        type: string
+        description: 'Type of the origin: EDS_SITE or SKYLINE_ENVIRONMENT'
+        enum:
+          - EDS_SITE
+          - SKYLINE_ENVIRONMENT
+  SslCertificateRepresentation:
+    type: object
+    properties:
+      id:
+        type: integer
+        format: int64
+        description: id
+      programId:
+        type: integer
+        format: int64
+        example: 14
+        description: Identifier of the application. Unique within the space.
+      serialNumber:
+        type: string
+        description: Unique identifier of the certificate at CA level.
+      name:
+        type: string
+        example: Certificate Name Example
+        description: Name of the SSL Certificate.
+      issuer:
+        type: string
+        description: Issuer of the SSL Certificate.
+      expireAt:
+        type: integer
+        format: int64
+        description: Expiration date of the SSL Certificate.
+      commonName:
+        type: string
+        description: Common name of the SSL Certificate.
+      subjectAlternativeNames:
+        type: array
+        description: Subject alternative names of the SSL Certificate.
+        items:
+          type: string
+      certificate:
+        type: string
+        description: Encrypted content of the SSL Certificate.
+      chain:
+        type: string
+        description: Content of the Chain File.
+      createdAt:
+        type: integer
+        format: int64
+        description: Date of SSL Certificate submission.
+      updatedAt:
+        type: integer
+        format: int64
+        description: Date of last SSL Certificate update.
+      _links:
+        type: object
+        readOnly: true
+        properties:
+          self:
+            $ref: '#/definitions/HalLink'
+            description: This object's representation
+    description: Describes an SSL Certificate
+  StackTraceElement:
+    type: object
+    properties:
+      classLoaderName:
+        type: string
+      moduleName:
+        type: string
+      moduleVersion:
+        type: string
+      methodName:
+        type: string
+      fileName:
+        type: string
+      lineNumber:
+        type: integer
+        format: int32
+      className:
+        type: string
+      nativeMethod:
+        type: boolean
+        default: false
+  SslCertificateNotFoundException:
+    type: object
+    properties:
+      stackTrace:
+        type: array
+        items:
+          $ref: '#/definitions/StackTraceElement'
+      message:
+        type: string
+      localizedMessage:
+        type: string
+  SecretString:
+    type: object
+    properties:
+      value:
+        type: string
+        example: my-secret
+        description: >-
+          Secret value for updating the secrets, null for not updating the
+          existing secret
+      path:
+        type: string
+        example: /path/to/secret
+        description: Path to the secret value
+  CreateOrUpdateSslCertificateBody:
+    type: object
+    required:
+      - name
+      - certificate
+      - privateKey
+      - chain
+    properties:
+      name:
+        type: string
+        description: The name of the new SSL Certificate.
+      certifcate:
+        type: string
+        description: The PEM-encoded certificate.
+      privateKey:
+        type: string
+        description: The PEM-encoded private key.
+      chain:
+        type: array
+        items:
+          type: string
+        description: The PEM-encoded certificate chain.
+  AllSSLCertificatesList:
+    type: object
+    properties:
+      _totalNumberOfItems:
+        type: integer
+        format: int32
+        description: The total number of embedded items
+      _page:
+        $ref: '#/definitions/RequestedPageDetails'
+        description: Details of the requested page of items
+      _embedded:
+        type: object
+        readOnly: true
+        properties:
+          certificates:
+            type: array
+            items:
+              $ref: '#/definitions/SslCertificateRepresentation'
+      _links:
+        type: object
+        readOnly: true
+        properties:
+          next:
+            $ref: '#/definitions/HalLink'
+            description: The next page of results.
+          page:
+            $ref: '#/definitions/HalLink'
+            description: An arbitrary page of results.
+          prev:
+            $ref: '#/definitions/HalLink'
+            description: The previous page of results.
+          self:
+            $ref: '#/definitions/HalLink'
+            description: This object's representation
+  CreateDvCertificateBody:
+    type: object
+    required:
+      - domainIds
+    properties:
+      name:
+        type: string
+        example: my-cert
+        description: Name of the certificate
+      domainIds:
+        type: array
+        description: List of domain IDs to associate with the certificate
+        items:
+          type: integer
+          format: int64
+  Site:
+    type: object
+    properties:
+      siteId:
+        type: integer
+        format: int64
+        description: siteId
+      programId:
+        type: string
+        description: Identifier of the CM Program ID. Unique within the space.
+      siteName:
+        type: string
+        description: Name of the site
+      repoUrl:
+        type: string
+        description: CM Eds Site Repo URL.
+      siteStatus:
+        type: string
+        description: Site EDS status
+      validationToken:
+        type: string
+        description: Validation token of the CM EDS Site
+      createdAt:
+        type: integer
+        format: int64
+        description: Creation date
+      modifiedAt:
+        type: integer
+        format: int64
+        description: Last modification date
+      deletedAt:
+        type: integer
+        format: int64
+        description: Deleted date
+      deleted:
+        type: boolean
+        description: deleted or not
+        default: false
+      _links:
+        type: object
+        readOnly: true
+        properties:
+          self:
+            $ref: '#/definitions/HalLink'
+            description: This object's representation
+          sites:
+            $ref: '#/definitions/HalLink'
+    description: Describes a Site
+  SiteList:
+    type: object
+    properties:
+      _totalNumberOfItems:
+        type: integer
+        format: int32
+        description: The total number of embedded items
+      _embedded:
+        type: object
+        readOnly: true
+        properties:
+          sites:
+            type: array
+            items:
+              $ref: '#/definitions/Site'
+      _links:
+        type: object
+        readOnly: true
+        properties:
+          self:
+            $ref: '#/definitions/HalLink'
+            description: This object's representation


### PR DESCRIPTION
Content Sets Tag has had a new API added into its existing list of API. This API is for checking the compatibility between 2 environments (source and destination before running content copy).

You can take a look at 
1. Only change added is in the api.yaml file which has a new API added with contentSets tag. It includes 2 definitions declarations for the Input and Response of API.

## How Has This Been Tested?
Tested via running it locally and checking the reponse images.

## Screenshots (if appropriate):
<img width="817" alt="image" src="https://github.com/user-attachments/assets/c07cfc6e-0bbf-4221-8f16-5457853c4a79">
<img width="815" alt="image" src="https://github.com/user-attachments/assets/c6a858bf-e64a-458e-b022-2d0394718630">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
