### PR TITLE
docs: add BGP dynamic routing fields to network infrastructure spec

### DIFF
--- a/static/api.yaml
+++ b/static/api.yaml
@@ -7613,14 +7613,13 @@ definitions:
     type: object
     required:
       - address
-      - addressSpace
     properties:
       address:
         type: string
         description: Customer VPN Device IP Address
       addressSpace:
         type: array
-        description: IP Ranges to route through the VPN
+        description: 'IP Ranges (CIDRs) to route through the VPN. Required for static-routing connections. Optional when the connection uses BGP dynamic routing (bgpAsn and bgpPeeringAddress provided), in which case routes are learned dynamically. When both a BGP-advertised route and a static addressSpace route overlap, the most specific (longest-prefix) subnet is preferred.'
         items:
           type: string
   IpSecPolicyInfrastructure:
@@ -7725,6 +7724,15 @@ definitions:
       sharedKey:
         type: string
         description: Customer VPN preshared key
+      bgpAsn:
+        type: integer
+        description: 'Customer-side BGP Autonomous System Number for dynamic routing. No range restriction. Must be provided together with bgpPeeringAddress.'
+      bgpPeeringAddress:
+        type: string
+        description: 'Customer-side BGP peering IP address. Must be a valid IPv4 address. Must be provided together with bgpAsn.'
+      adobeApipaAddress:
+        type: string
+        description: 'Adobe-side APIPA address used for BGP peering. When provided, must be in the range 169.254.21.0 to 169.254.22.255. If omitted, Adobe auto-assigns an IP from infrastructure-level address space.'
       ipsecPolicy:
         description: IPSec Policy
         $ref: '#/definitions/IpSecPolicyInfrastructure'
@@ -7789,9 +7797,12 @@ definitions:
       dns:
         description: DNS Information. Only applicable to VPN infrastructures.
         $ref: '#/definitions/DnsConfiguration'
+      adobeAsn:
+        type: integer
+        description: 'ASN of the Adobe-configured VPN gateway. Optional in general, but mandatory when any connection specifies bgpAsn or bgpPeeringAddress. Must be in the range 64512 to 65514 or 65521 to 65534. Only applicable to VPN.'
       connections:
         type: array
-        description: List of VPN connections
+        description: 'List of VPN connections. Supports multiple connections per network infrastructure (recommended maximum of 20). Connections can mix static and BGP dynamic routing.'
         items:
           $ref: '#/definitions/VpnConnection'
       statusDetails:

--- a/static/models.yaml
+++ b/static/models.yaml
@@ -1298,14 +1298,13 @@ components:
       type: object
       required:
         - address
-        - addressSpace
       properties:
         address:
           type: string
           description: Customer VPN Device IP Address
         addressSpace:
           type: array
-          description: IP Ranges to route through the VPN
+          description: "IP Ranges (CIDRs) to route through the VPN. Required for static-routing connections. Optional when the connection uses BGP dynamic routing (bgpAsn and bgpPeeringAddress provided), in which case routes are learned dynamically. When both a BGP-advertised route and a static addressSpace route overlap, the most specific (longest-prefix) subnet is preferred."
           items:
             type: string
     GoLiveDates:
@@ -1692,9 +1691,12 @@ components:
         dns:
           description: DNS Information. Only applicable to VPN infrastructures.
           $ref: "#/components/schemas/DnsConfiguration"
+        adobeAsn:
+          type: integer
+          description: "ASN of the Adobe-configured VPN gateway. Optional in general, but mandatory when any connection specifies bgpAsn or bgpPeeringAddress. Must be in the range 64512 to 65514 or 65521 to 65534. Only applicable to VPN."
         connections:
           type: array
-          description: List of VPN connections
+          description: "List of VPN connections. Supports multiple connections per network infrastructure (recommended maximum of 20). Connections can mix static and BGP dynamic routing."
           items:
             $ref: "#/components/schemas/VpnConnection"
         statusDetails:
@@ -3271,6 +3273,15 @@ components:
         sharedKey:
           type: string
           description: Customer VPN preshared key
+        bgpAsn:
+          type: integer
+          description: "Customer-side BGP Autonomous System Number for dynamic routing. No range restriction. Must be provided together with bgpPeeringAddress."
+        bgpPeeringAddress:
+          type: string
+          description: "Customer-side BGP peering IP address. Must be a valid IPv4 address. Must be provided together with bgpAsn."
+        adobeApipaAddress:
+          type: string
+          description: "Adobe-side APIPA address used for BGP peering. When provided, must be in the range 169.254.21.0 to 169.254.22.255. If omitted, Adobe auto-assigns an IP from infrastructure-level address space."
         ipsecPolicy:
           description: IPSec Policy
           $ref: "#/components/schemas/IpSecPolicyInfrastructure"


### PR DESCRIPTION
## Description

Mirrors the BGP dynamic routing additions across **both** published specs (`static/api.yaml` and `static/models.yaml`) for the VPN network infrastructure schemas:

- **VpnConnection** — added `bgpAsn`, `bgpPeeringAddress`, `adobeApipaAddress`
- **NetworkInfrastructure** — added `adobeAsn`; documented multi-connection support (recommended max 20) and static/BGP mix in the `connections` description
- **GatewayInfrastructure** — `addressSpace` is no longer required (it's optional when a connection uses BGP dynamic routing; required only for static-routing connections)

## Related Issue

N/A — documentation update tracking the network-infrastructure BGP feature.

## Motivation and Context

The self-service-gateway now supports BGP dynamic routing for VPN network infrastructures. The public API reference did not describe the new fields (`bgpAsn`, `bgpPeeringAddress`, `adobeApipaAddress`, `adobeAsn`) or the relaxed `addressSpace` requirement, so integrators had no documented way to configure dynamic routing. This change brings the two published specs in line with the implementation. Field descriptions and constraints were verified against the cm-hub `self-service-gateway` source of truth (`VpnInfrastructureRepresentation`, `NetworkInfrastructureService`).

## How Has This Been Tested?

- Both `static/api.yaml` and `static/models.yaml` parse cleanly as YAML.
- Each documented constraint cross-checked against cm-hub validation code (APIPA range `169.254.21.0–169.254.22.255`, `adobeAsn` range `64512–65514`/`65521–65534`, bgpAsn↔bgpPeeringAddress co-presence, `MAX_VPN_CONNECTIONS = 20`, conditional `addressSpace` requirement).

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

> Generated with assistance from Claude Code (claude.ai/code)
